### PR TITLE
Add 1 day before the appointment

### DIFF
--- a/src/components/AdvancedSlideBar.vue
+++ b/src/components/AdvancedSlideBar.vue
@@ -27,6 +27,7 @@
             <option value="30">{{ t('appointments', '30 Minutes') }}</option>
             <option value="60">{{ t('appointments', '1 Hour') }}</option>
             <option value="120">{{ t('appointments', '2 Hours') }}</option>
+            <option value="720">{{ t('appointments', '1 Day') }}</option>
           </select>
           <label
               class="tsb-label"


### PR DESCRIPTION
We need to be warn 1 day before the appointment

Translation in French : "1 Day" : "1 Jour"

You will ask : "Why 720 minutes (12 hours) instead of 1440 (24 hours * 60 minutes) ?"

Because, in case of working hours : 8 AM to 6 PM, we want people can book the next day...
Imagine if someone book at 5:30PM, he can see the next appointment on next day at 8 AM