### PR TITLE
feat: require caldav backend

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,6 +29,7 @@
     <screenshot>https://raw.githubusercontent.com/SergeyMosin/Appointments/master/screenshots/screenshot3.jpg</screenshot>
     <dependencies>
         <nextcloud min-version="27" max-version="29"/>
+        <backend>caldav</backend>
     </dependencies>
     <repair-steps>
         <post-migration>


### PR DESCRIPTION
Will be required after https://github.com/nextcloud/server/pull/46510
See also https://github.com/nextcloud/documentation/pull/12048

- [x] Wait for https://github.com/nextcloud/appstore/pull/1414 (to pass validation)

## Context

The CalDAV server settings for admins will be hidden if no app requires the CalDAV backend. Apps should require the backend via `info.xml`.

Please let me know if you have any further questions or feedback.