### PR TITLE
feat: Pre-Fill input fields given url query parameter

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -19,7 +19,7 @@
 
 
 		makeDpu(f.getAttribute("data-pps"))
-		prefillFields(document.getElementById('srgdev-ncfp-main-inputs').children)
+		prefillFields(document.getElementById('srgdev-ncfp-main-inputs'))
 		document.getElementById("srgdev-ncfp_sel-dummy").addEventListener("click", selClick)
 		document.getElementById("srgdev-ncfp_sel-dummy").addEventListener("keyup", function (evt) {
 			if (isSpaceKey(evt)) {
@@ -46,10 +46,10 @@
 		const urlParams = new URLSearchParams(window.location.search);
 		if (urlParams) {
 			const hidePrefilledInputs = urlParams.has('hidePrefilledInputs')
+			const disablePrefilledInputs = urlParams.has('disablePrefilledInputs')
 
 			// iterate over every formInputs and check if there is a query parameter with the same name
-			for (let i = 0, elm, l = formInputs.length; i < l; i++) {
-				elm = formInputs[i]
+			for (let elm of formInputs.children) {
 				if (urlParams.has(elm.name)) {
 					// set the input's value
 					elm.value = urlParams.get(elm.name)
@@ -61,6 +61,21 @@
 						if (label) {
 							label.style.display = 'none'
 						}
+					} else if (disablePrefilledInputs) {
+						// set field to disabled
+						elm.disabled = true
+
+						// create a label containing the input value
+						const valueLabel = document.createElement('label')
+						valueLabel.textContent = elm.value
+						valueLabel.style.display = 'block'
+						valueLabel.style.fontWeight = 'bold'
+
+						// append the label after the input
+						formInputs.insertBefore(valueLabel, elm.nextSibling)
+
+						// hide the field
+						elm.style.display = 'none'
 					}
 				}
 			}

--- a/src/form.js
+++ b/src/form.js
@@ -19,6 +19,7 @@
 
 
 		makeDpu(f.getAttribute("data-pps"))
+		prefillFields(document.getElementById('srgdev-ncfp-main-inputs').children)
 		document.getElementById("srgdev-ncfp_sel-dummy").addEventListener("click", selClick)
 		document.getElementById("srgdev-ncfp_sel-dummy").addEventListener("keyup", function (evt) {
 			if (isSpaceKey(evt)) {
@@ -39,6 +40,31 @@
 			b.disabled = true;
 			b.textContent = txt
 		}, 900000)
+	}
+
+	function prefillFields(formInputs) {
+		const urlParams = new URLSearchParams(window.location.search);
+		if (urlParams) {
+			const hidePrefilledInputs = urlParams.has('hidePrefilledInputs')
+
+			// iterate over every formInputs and check if there is a query parameter with the same name
+			for (let i = 0, elm, l = formInputs.length; i < l; i++) {
+				elm = formInputs[i]
+				if (urlParams.has(elm.name)) {
+					// set the input's value
+					elm.value = urlParams.get(elm.name)
+
+					// if hidePrefilledInputs == true, we want to hide that input component and any label for="inputID"
+					if (hidePrefilledInputs) {
+						elm.style.display = 'none'
+						const label = document.querySelector(`label[for="${elm.id}"]`)
+						if (label) {
+							label.style.display = 'none'
+						}
+					}
+				}
+			}
+		}
 	}
 
 	function gdprCheck() {

--- a/templates/help.php
+++ b/templates/help.php
@@ -218,6 +218,29 @@ form{
     </p>
     <br>
 
+    <h2 class="srgdev-appt-hs-h1">Pre-fill fields</h2>
+    <p class="srgdev-appt-hs-p">
+        <strong id="srgdev-sec_confirmedUrl">Redirect Confirmed URL</strong> - when this URL is specified visitors will be redirected there after they confirm their email address. A base64 encoded
+        <code class="srgdev-appt-hs-code_short">d=...</code> query parameter containing a JSON object will be added to the URL. Final URL for
+        <span style="font-style: italic; white-space: nowrap">https://your-cool-domain.com/finish.html</span> might look something like this:
+        <span style="font-style: italic; white-space: nowrap">https://your-cool-domain.com/finish.html?d=eyJpbml0aWFsQ29uZmlybSI6dHJ1ZSwiaWQiOiI4YjhkOD...</span>
+    </p>
+    <p class="srgdev-appt-hs-p">
+        You can pre-fill fields in the form by adding a URL query parameter with the form
+        <code class="srgdev-appt-hs-code_short">name=value</code>.
+    <pre><code class="srgdev-appt-hs-code">
+http(s)://your.domain.com/page_url?name=YourCustomerNameSurname&email=email@domain.com
+    </code></pre>
+    </p>
+    <p class="srgdev-appt-hs-p">
+        It is also possible to programatically set those fields and hide them, so they are submitted, by setting
+        <code class="srgdev-appt-hs-code_short">hidePrefilledInputs=true</code>.
+    <pre><code class="srgdev-appt-hs-code">
+http(s)://your.domain.com/page_url?name=YourCustomerNameSurname&email=email@domain.com&hidePrefilledInputs=true
+    </code></pre>
+    </p>
+    <br>
+
     <h2 class="srgdev-appt-hs-h1">iFrame/Embedding</h2>
     <div class="srgdev-appt-hs-p">
         1. If the iframe is under a different domain use <strong>occ</strong> to set allowed Frame Ancestor Domain:


### PR DESCRIPTION
This PR implements pre-filling form fields given url query parameters, as requested in #145 

 I have implemented this feature in the formReady method. For ease-of-use, it follows the same standard as cal.com:

> You can add anywhere in the booking flow before the booking form page or in the booking form page itself. Simply add these in the URL and you're good to go!
> https://cal.com/johndoe/book?email=johndoe%40example.com&phone=1234
> Source: https://cal.com/docs/core-features/bookings/prefill-fields#pre-filling-all-fields

It also implements hiding the pre-filled inputs, so that in custom embed flows, we could just iframe the appointments app with the calendar component by setting `hidePrefilledInputs=true`
```
https://mycloud.tld/appointments/appointmentID?name=UserName&email=userEmail&hidePrefilledInputs=true
```

This PR also updates the documentation, referencing this change.