### PR TITLE
Remove placeholder location when location is unset

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -980,9 +980,7 @@ class PageController extends Controller
             $org_name = $this->l->t('Organization Name');
         }
         $addr = trim($addr);
-        if (empty($addr)) {
-            $addr = "123 Main Street\nNew York, NY 45678";
-        } elseif (filter_var($addr, FILTER_VALIDATE_URL) !== false) {
+        if (!empty($addr) and filter_var($addr, FILTER_VALIDATE_URL) !== false) {
             $addr = $this->l->t("Online Meeting");
         }
         if (empty($ft)) {


### PR DESCRIPTION
Fairly simple one - just removes the placeholder New York location that is set if the location field is empty. I personally can't see a production need for the placeholder location so can't envisage any backwards compatibility/other issues with removing this.

This addresses #528.