### PR TITLE
added starting time for simple appointment grid

### DIFF
--- a/src/components/views/TimeSlotEditor.vue
+++ b/src/components/views/TimeSlotEditor.vue
@@ -194,9 +194,10 @@ const handleSimpleAddAppts = (index) => {
 		showError(t('appointments', 'Invalid number of appointments'))
 		return
 	}
+	const starterTime = Math.floor((hd.startTime.getHours() *60 + hd.startTime.getMinutes() - gridMaker.SH_OFFSET * 60) / 5);
 	editor.menuIndex = -1
 	const dur = isNaN(props.data.dur) || props.data.dur < 5 ? 5 : props.data.dur
-	gridMaker.addAppt(0, dur, n, index, props.data.calColor)
+	gridMaker.addAppt(starterTime, dur, n, index, props.data.calColor)
 	hd.hasAppts = true
 }
 
@@ -284,6 +285,13 @@ const gridApptsCopy = (index) => {
 							</template>
 							{{ t('appointments', 'Add Appointments') }}
 						</NcActionButton>
+						<NcActionInput
+								v-if="gridMode===gridMaker.MODE_SIMPLE"
+								:value.sync="hi.startTime"
+								type="time"
+								label="Starting from"
+								format="HH:mm">
+						</NcActionInput>
 						<NcActionButton
 								:disabled="!hi.hasAppts"
 								:closeAfterClick="true"

--- a/src/grid.js
+++ b/src/grid.js
@@ -722,6 +722,8 @@ function _apptGridMaker() {
 			}
 		}
 
+		const startTime = new Date()
+		startTime.setHours(SH_OFFSET, 0, 0)
 		const header = []
 		for (let ts = startDate.getTime(), i = 0; i < n; i++) {
 			header[i] = {
@@ -730,6 +732,7 @@ function _apptGridMaker() {
 				w: w,
 				n: '8',// Initial value for "add" input must be string
 				hasAppts: false,
+				startTime: startTime
 			}
 			ts = startDate.setDate(startDate.getDate() + 1)
 		}
@@ -739,6 +742,7 @@ function _apptGridMaker() {
 	return {
 		MODE_SIMPLE: MODE_SIMPLE,
 		MODE_TEMPLATE: MODE_TEMPLATE,
+		SH_OFFSET: SH_OFFSET,
 		setup: setup,
 		addAppt: addAppt,
 		cloneColumns: cloneColumns,


### PR DESCRIPTION
This PR adds a starting time in the simple mode, addressing the second commit in #596.
It leaves the default value at 8AM, but allows for other times.

I am not an expert in vue, so the visual for the NcDateTimePicker could be improved, as it is currently cropped. I tried adding "appendToBody" and increasing the z-index, but some blur or focus-magic from vue prevent the selection, so i removed this part.