### PR TITLE
Correct spelling of 'finalize' to 'finalise'

### DIFF
--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -78,7 +78,7 @@ OC.L10N.register(
     "Link Expired …" : "Link Expired …",
     "An email with additional details is on its way to you at %s" : "An email with additional details is on its way to you at %s",
     "Almost done …" : "Almost done …",
-    "We have sent an email to %s, please open it and click on the confirmation link to finalize your appointment request" : "We have sent an email to %s, please open it and click on the confirmation link to finalize your appointment request",
+    "We have sent an email to %s, please open it and click on the confirmation link to finalize your appointment request" : "We have sent an email to %s, please open it and click on the confirmation link to finalise your appointment request",
     "Human verification failed" : "Human verification failed",
     "Internal server error: validation request failed" : "Internal server error: validation request failed",
     "We regret to inform you that your email address has been blocked due to activity that violates our community guidelines." : "We regret to inform you that your email address has been blocked due to activity that violates our community guidelines.",


### PR DESCRIPTION
Small localisation fix for British English, same as the json