### PR TITLE
Allow specifying "data" attributes for extra form fields

### DIFF
--- a/lib/Controller/StateController.php
+++ b/lib/Controller/StateController.php
@@ -833,6 +833,11 @@ class StateController extends Controller
         ];
         $applyAttrs = function (array $allowed) use ($obj) {
             $out = '';
+            foreach ($obj as $attr => $value) {
+              if (preg_match("/^data\-[a-z0-9\-_]+$/",$attr)) {
+                $out .= ' ' . $attr . '="' . htmlspecialchars($value, ENT_QUOTES, 'UTF-8') . '"';
+              }
+            }
             foreach ($allowed as $attr => $default) {
                 if ($attr === 'required' && !empty($obj[$attr])) {
                     $out .= ' required';


### PR DESCRIPTION
Hey :-)

This looks like a good starting point to enable 'Custom appointment location' (#606). It also opens the door to reusing form data for eg  JS-driven conditional form fields or substitutions in the confirmation emails and ICS description text.

