### PR TITLE
fix: correct blob: addAllowedWorkerSrcDomain CSP directive

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -545,7 +545,7 @@ class PageController extends Controller
         if (!$csp) {
             $csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();
         }
-        $csp->addAllowedWorkerSrcDomain('blob');
+        $csp->addAllowedWorkerSrcDomain('blob:');
         $res->setContentSecurityPolicy($csp);
         return $res;
     }


### PR DESCRIPTION
addAllowedWorkerSrcDomain('blob') was missing the colon, causing Nextcloud to emit "worker-src https://blob" an invalid origin that browser reject. The refactored confirm/cancel flow introduced in #646 breaking the appointment confirmation for users.

Use 'blob:' insted of 'blob' so Nextcloud emits the correct directive.