### PR TITLE
fix(settings): crash when closing the Directory Page settings dialog

### DIFF
--- a/src/components/settings-v2/Settings.vue
+++ b/src/components/settings-v2/Settings.vue
@@ -62,7 +62,7 @@ onMounted(() => {
 const handleUpdateOpen = (evt) => {
 	if (evt === false) {
 		settingsStore.cancelServiceRequest(CK.SETTINGS)
-		if (pageSettingsLoaded) {
+		if (pageSettingsLoaded && !_isDir) {
 			pagesStore.getPageById(props.pageId).tsMode = settingsStore.settings.tsMode
 		}
 		emit('close-settings')


### PR DESCRIPTION
NC 34.0.3, Appointments 2.7.4:

1. Open Directory Page → Settings
2. Close the dialog

Result: toast "error: page not found", console error `Cannot set properties of null (setting 'tsMode')`, and no settings dialog opens again until page reload — the throw lands before `emit('close-settings')`, so `settingsPageId` in App2 is never cleared.

The pages store only holds `type === 'page'` entries, so the lookup misses for `'d0'` — and a directory page has no tsMode to sync back anyway. Guarded the sync with the existing `_isDir`, like the `label` computed above.

Verified against NC 34.0.3 with a rebuilt bundle: clean close, dialogs reopen, no console errors.
