### PR TITLE
Fixes for screen reader accessibility

### DIFF
--- a/lib/Controller/StateController.php
+++ b/lib/Controller/StateController.php
@@ -853,7 +853,7 @@ class StateController extends Controller
                 if (($obj['type'] === 'checkbox' || $obj['type'] === 'radio') && isset($obj['options']) && is_array($obj['options'])) {
                     $class = 'srgdev-ncfp-form-' . $obj['type'];
                     $nameSuffix = $obj['type'] === 'checkbox' ? '[]' : '';
-                    $r .= '<div class="srgdev-ncfp-form-fieldset">';
+                    $r .= '<fieldset class="srgdev-ncfp-form-fieldset">';
                     $r .= '<legend class="srgdev-ncfp-form-label">' . $obj['label'] . '</legend>';
                     foreach ($obj['options'] as $optIndex => $optValue) {
                         $optValEscaped = htmlspecialchars($optValue, ENT_QUOTES, 'UTF-8');
@@ -863,7 +863,7 @@ class StateController extends Controller
                         $r .= '<label for="' . $optId . '">' . $optValEscaped . '</label>';
                         $r .= '</p>';
                     }
-                    $r .= '</div>';
+                    $r .= '</fieldset>';
                     return $r;
                 }
                 $class = 'srgdev-ncfp-form-input';

--- a/scss/form.scss
+++ b/scss/form.scss
@@ -647,6 +647,17 @@ $tz-cont-height: 2.5em;
 
 // ---- THANK YOU NOTE ------
 
+.srgdev-ncfp-form-fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.srgdev-ncfp-form-fieldset legend {
+  padding: 0;
+}
+
 .srgdev-appt-info-cont {
   margin-top: 3em;
   max-width: 40em;

--- a/src/components/LabelAccordion.vue
+++ b/src/components/LabelAccordion.vue
@@ -59,9 +59,15 @@ const toggleOpen = () => {
 			</span>
 			</label>
 			<div v-if="slots?.helpPopover" class="wrapper-help">
-				<NcPopover :focus-trap="false">
-					<template #trigger>
-						<IconInfo class="wrapper-help-icon" :size="16"/>
+				<NcPopover :focus-trap="false" :container="false">
+					<template #trigger="{attrs}">
+						<button
+								type="button"
+								class="wrapper-help-button"
+								v-bind="attrs"
+								:aria-label="t('appointments', 'Help')">
+							<IconInfo class="wrapper-help-icon" :size="16"/>
+						</button>
 					</template>
 					<template>
 						<div class="wrapper-help-content">
@@ -128,6 +134,21 @@ const toggleOpen = () => {
 .wrapper-help-icon {
 	cursor: pointer;
 	opacity: .5;
+}
+
+.wrapper-help-button {
+	background: none;
+	border: none;
+	border-radius: 0;
+	margin: 0;
+	padding: 0;
+	min-height: 0;
+	display: inline-flex;
+	color: inherit;
+}
+
+.wrapper-help-button:focus-visible .wrapper-help-icon {
+	opacity: 1;
 }
 
 .wrapper-help-content {

--- a/src/components/LabelAccordion.vue
+++ b/src/components/LabelAccordion.vue
@@ -58,7 +58,7 @@ const toggleOpen = () => {
 				{{ label }}
 			</span>
 				<span v-if="loading" class="wrapper-label-loading">
-				<NcLoadingIcon :size="16"/>
+				<NcLoadingIcon :size="16" :name="t('appointments', 'Loading')"/>
 			</span>
 			</component>
 			<div v-if="slots?.helpPopover" class="wrapper-help">

--- a/src/components/LabelAccordion.vue
+++ b/src/components/LabelAccordion.vue
@@ -37,7 +37,10 @@ const toggleOpen = () => {
 <template>
 	<div>
 		<div class="flex-wrapper">
-			<label
+			<component
+					:is="accordion ? 'button' : 'label'"
+					:type="accordion ? 'button' : null"
+					:aria-expanded="accordion ? String(isOpen) : null"
 					v-bind="$attrs"
 					@click="toggleOpen"
 					:class="[
@@ -57,7 +60,7 @@ const toggleOpen = () => {
 				<span v-if="loading" class="wrapper-label-loading">
 				<NcLoadingIcon :size="16"/>
 			</span>
-			</label>
+			</component>
 			<div v-if="slots?.helpPopover" class="wrapper-help">
 				<NcPopover :focus-trap="false" :container="false">
 					<template #trigger="{attrs}">
@@ -95,6 +98,18 @@ const toggleOpen = () => {
 	display: inline-block;
 	overflow: hidden;
 	vertical-align: middle;
+}
+
+button.wrapper-label {
+	background: none;
+	border: none;
+	border-radius: 0;
+	margin: 0;
+	padding: 0;
+	min-height: 0;
+	font: inherit;
+	color: inherit;
+	text-align: start;
 }
 
 .wrapper-label-accordion,

--- a/src/components/LabelAccordion.vue
+++ b/src/components/LabelAccordion.vue
@@ -1,3 +1,9 @@
+<script>
+export default {
+	inheritAttrs: false
+}
+</script>
+
 <script setup>
 import IconMenu from "vue-material-design-icons/MenuSwapOutline.vue";
 import IconInfo from "vue-material-design-icons/InformationOutline.vue";

--- a/src/components/Navigation2.vue
+++ b/src/components/Navigation2.vue
@@ -154,6 +154,7 @@ const handleActionsMenu = (pageId, evt) => {
 							<NcLoadingIcon v-if="pagesStore.loading===LOADING_LABEL" :size="20"/>
 							<IconPencil v-else :size="20"/>
 						</template>
+						{{ t('appointments', 'Page name') }}
 					</NcActionInput>
 					<NcActionButton
 							:disabled="!!pagesStore.loading"

--- a/src/components/PsSelect.vue
+++ b/src/components/PsSelect.vue
@@ -4,13 +4,14 @@ let idCounter = 0
 
 <script setup>
 import {NcSelect} from "@nextcloud/vue";
-import {computed, useAttrs} from "vue";
+import {computed, nextTick, ref, useAttrs} from "vue";
 
 const props = defineProps({
 	selectedValue: [Number, String],
 	placeholderLabel: String
 })
 const attrs = useAttrs()
+const select = ref(null)
 const valueId = `ps-select-value-${++idCounter}`
 
 const selectedOption = computed(() => {
@@ -23,12 +24,25 @@ const selectedOption = computed(() => {
 	}
 })
 
+// The dropdown is appended to <body>; moving it into the enclosing dialog keeps focus inside the dialog while it is open
+const handleOpen = () => nextTick(() => {
+	const el = select.value.$el
+	const dialog = el.closest('[role="dialog"]')
+	const menuId = el.querySelector('.vs__search').getAttribute('aria-owns')
+	const menu = document.querySelector(`#${CSS.escape(menuId)}.vs__dropdown-menu`)
+	if (dialog && menu && menu.parentElement !== dialog) {
+		dialog.appendChild(menu)
+	}
+})
+
 </script>
 
 <template>
 	<NcSelect
+			ref="select"
 			v-bind="$attrs"
 			v-on="$listeners"
+			@open="handleOpen"
 			:value="selectedOption"
 			:labelOutside="true"
 			:searchable="false"

--- a/src/components/PsSelect.vue
+++ b/src/components/PsSelect.vue
@@ -1,3 +1,7 @@
+<script>
+let idCounter = 0
+</script>
+
 <script setup>
 import {NcSelect} from "@nextcloud/vue";
 import {computed, useAttrs} from "vue";
@@ -7,14 +11,16 @@ const props = defineProps({
 	placeholderLabel: String
 })
 const attrs = useAttrs()
+const valueId = `ps-select-value-${++idCounter}`
 
-const selectedLabel = computed(() => {
+const selectedOption = computed(() => {
 	const opt = attrs.options.find((item) => item.value === props.selectedValue)
-	return opt
-			? opt.label
-			: props.placeholderLabel
-					? props.placeholderLabel
-					: t('appointments', 'Select One Option')
+	return opt || {
+		label: props.placeholderLabel
+				? props.placeholderLabel
+				: t('appointments', 'Select One Option'),
+		value: props.selectedValue
+	}
 })
 
 </script>
@@ -23,10 +29,21 @@ const selectedLabel = computed(() => {
 	<NcSelect
 			v-bind="$attrs"
 			v-on="$listeners"
-			:value="selectedLabel"
+			:value="selectedOption"
 			:labelOutside="true"
+			:searchable="false"
 			class="ps-nc-select-internal"
-			:clearable="false"/>
+			:clearable="false">
+		<template #search="{attributes, events}">
+			<input
+					class="vs__search"
+					dir="auto"
+					v-bind="attributes"
+					v-on="events"
+					:aria-describedby="valueId">
+			<span :id="valueId" class="hidden-visually">{{ selectedOption.label }}</span>
+		</template>
+	</NcSelect>
 </template>
 
 <style scoped>

--- a/src/components/PsSelect.vue
+++ b/src/components/PsSelect.vue
@@ -24,6 +24,9 @@ const selectedOption = computed(() => {
 	}
 })
 
+// Dropping the focus handler stops the list from opening when the field is merely tabbed to; Down/Enter/Space and mouse still open it
+const withoutFocus = ({focus, ...events}) => events
+
 // The dropdown is appended to <body>; moving it into the enclosing dialog keeps focus inside the dialog while it is open
 const handleOpen = () => nextTick(() => {
 	const el = select.value.$el
@@ -53,7 +56,7 @@ const handleOpen = () => nextTick(() => {
 					class="vs__search"
 					dir="auto"
 					v-bind="attributes"
-					v-on="events"
+					v-on="withoutFocus(events)"
 					:aria-describedby="valueId">
 			<span :id="valueId" class="hidden-visually">{{ selectedOption.label }}</span>
 		</template>

--- a/src/components/PsSelect.vue
+++ b/src/components/PsSelect.vue
@@ -9,21 +9,15 @@ import {computed, nextTick, ref, useAttrs} from "vue";
 
 const props = defineProps({
 	selectedValue: [Number, String],
-	placeholderLabel: String
+	placeholderLabel: String,
+	required: Boolean
 })
 const attrs = useAttrs()
 const select = ref(null)
 const valueId = `ps-select-value-${++idCounter}`
 
-const selectedOption = computed(() => {
-	const opt = attrs.options.find((item) => item.value === props.selectedValue)
-	return opt || {
-		label: props.placeholderLabel
-				? props.placeholderLabel
-				: t('appointments', 'Select One Option'),
-		value: props.selectedValue
-	}
-})
+const selectedOption = computed(() => attrs.options.find((item) => item.value === props.selectedValue) || null)
+const placeholder = computed(() => props.placeholderLabel || t('appointments', 'Select One Option'))
 
 // Dropping the focus handler stops the list from opening when the field is merely tabbed to; Down/Enter/Space and mouse still open it
 const withoutFocus = ({focus, ...events}) => events
@@ -48,6 +42,8 @@ const handleOpen = () => nextTick(() => {
 			v-on="$listeners"
 			@open="handleOpen"
 			:value="selectedOption"
+			:placeholder="placeholder"
+			:required="required"
 			:labelOutside="true"
 			:searchable="false"
 			class="ps-nc-select-internal"
@@ -63,10 +59,11 @@ const handleOpen = () => nextTick(() => {
 			<input
 					class="vs__search"
 					dir="auto"
+					:required="required && !selectedOption"
 					v-bind="attributes"
 					v-on="withoutFocus(events)"
 					:aria-describedby="valueId">
-			<span :id="valueId" class="hidden-visually">{{ selectedOption.label }}</span>
+			<span :id="valueId" class="hidden-visually">{{ selectedOption ? selectedOption.label : '' }}</span>
 		</template>
 	</NcSelect>
 </template>
@@ -95,7 +92,6 @@ const handleOpen = () => nextTick(() => {
 }
 
 .ps-nc-select-internal.v-select >>> .vs__search {
-	opacity: 0;
 	pointer-events: none;
 }
 </style>

--- a/src/components/PsSelect.vue
+++ b/src/components/PsSelect.vue
@@ -4,6 +4,7 @@ let idCounter = 0
 
 <script setup>
 import {NcSelect} from "@nextcloud/vue";
+import NcEllipsisedOption from "@nextcloud/vue/dist/Components/NcEllipsisedOption.js";
 import {computed, nextTick, ref, useAttrs} from "vue";
 
 const props = defineProps({
@@ -51,6 +52,13 @@ const handleOpen = () => nextTick(() => {
 			:searchable="false"
 			class="ps-nc-select-internal"
 			:clearable="false">
+		<template #option="option">
+			<span aria-hidden="true"><NcEllipsisedOption :name="String(option.label)"/></span>
+			<span class="hidden-visually">{{ option.label }}</span>
+		</template>
+		<template #selected-option="option">
+			<span aria-hidden="true"><NcEllipsisedOption :name="String(option.label)"/></span>
+		</template>
 		<template #search="{attributes, events}">
 			<input
 					class="vs__search"

--- a/src/components/modals/WeeklyApptsEditorModal.vue
+++ b/src/components/modals/WeeklyApptsEditorModal.vue
@@ -166,20 +166,20 @@ const primaryButtonText = props.data.elm === null
 			<template v-if="props.data.elm===null">
 				<LabelAccordion
 						:label="t('appointments', 'Number of Appointments')"
-						for="atam-slider-count"/>
+						id="atam-slider-count-label"/>
 				<vue-slider
 						:min="1"
 						:max="32"
 						tooltip="always"
 						tooltipPlacement="bottom"
-						id="atam-slider-count"
+						:dot-attrs="{'aria-labelledby': 'atam-slider-count-label'}"
 						class="ps-slider appt-slider"
 						v-model="state.count"/>
 			</template>
 			<div class="pml-cont">
-				<label class="slider-label">{{ t('appointments', 'Duration (hours:minutes)') }}</label>
-				<span class="pml-p" @click="addDurationHandler">+</span>
-				<span class="pml-m" @click="removeDurationHandler">−</span>
+				<label id="atam-slider-dur-label" class="slider-label">{{ t('appointments', 'Duration (hours:minutes)') }}</label>
+				<button type="button" class="pml-p" :aria-label="t('appointments', 'Add duration choice')" @click="addDurationHandler">+</button>
+				<button type="button" class="pml-m" :aria-label="t('appointments', 'Remove duration choice')" @click="removeDurationHandler">−</button>
 			</div>
 			<vue-slider
 					:min="5"
@@ -190,6 +190,7 @@ const primaryButtonText = props.data.elm === null
 					tooltip="always"
 					tooltipPlacement="bottom"
 					:tooltip-formatter="durationsTooltipFormatter"
+					:dot-attrs="{'aria-labelledby': 'atam-slider-dur-label'}"
 					class="ps-slider appt-slider"
 					v-model="state.durations"/>
 			<LabelAccordion
@@ -248,6 +249,13 @@ const primaryButtonText = props.data.elm === null
 
 .pml-m,
 .pml-p {
+	background: none;
+	border: none;
+	border-radius: 0;
+	margin: 0;
+	padding: 0;
+	min-height: 0;
+	font: inherit;
 	font-size: 125%;
 	position: absolute;
 	height: 1em;

--- a/src/components/settings-v2/ComboCheckbox.vue
+++ b/src/components/settings-v2/ComboCheckbox.vue
@@ -76,9 +76,15 @@ const handleClick = (evt) => {
 				@click.native.capture="handleClick"
 				@update:checked="(value)=>{store.setOne(propName,value);emit('value-updated',{propName: propName, value: value})}"/>
 		<div v-if="slots?.help" class="wrapper-checkbox-help">
-			<NcPopover>
-				<template #trigger>
-					<IconInfo class="wrapper-help-icon" :size="16"/>
+			<NcPopover :container="false">
+				<template #trigger="{attrs}">
+					<button
+							type="button"
+							class="wrapper-help-button"
+							v-bind="attrs"
+							:aria-label="t('appointments', 'Help')">
+						<IconInfo class="wrapper-help-icon" :size="16"/>
+					</button>
 				</template>
 				<template>
 					<div class="wrapper-help-content">
@@ -110,6 +116,21 @@ const handleClick = (evt) => {
 .wrapper-help-icon {
 	cursor: pointer;
 	opacity: .5;
+}
+
+.wrapper-help-button {
+	background: none;
+	border: none;
+	border-radius: 0;
+	margin: 0;
+	padding: 0;
+	min-height: 0;
+	display: inline-flex;
+	color: inherit;
+}
+
+.wrapper-help-button:focus-visible .wrapper-help-icon {
+	opacity: 1;
 }
 
 .wrapper-checkbox:hover .wrapper-help-icon {

--- a/src/components/settings-v2/ComboInput.vue
+++ b/src/components/settings-v2/ComboInput.vue
@@ -1,3 +1,7 @@
+<script>
+let idCounter = 0
+</script>
+
 <script setup>
 import {computed, useSlots} from "vue";
 import LabelAccordion from "../LabelAccordion.vue";
@@ -42,6 +46,7 @@ const props = defineProps({
 })
 
 const settings = props.store[props.settingsType];
+const inputId = `ps-combo-input-${++idCounter}`
 
 const isLoading = computed(() => props.store.loading[props.propName] === true)
 
@@ -63,6 +68,7 @@ const handleFocus = (evt) => {
 <template>
 	<div>
 		<LabelAccordion
+				:for="inputId"
 				:label="label"
 				:loading="isLoading">
 			<template #helpPopover v-if="slots?.help">
@@ -71,6 +77,7 @@ const handleFocus = (evt) => {
 		</LabelAccordion>
 		<textarea
 				v-if="type==='textarea'"
+				:id="inputId"
 				:placeholder="placeholder"
 				class="ps-textarea ps-vert-spacing"
 				v-model="settings[propName]"
@@ -78,6 +85,7 @@ const handleFocus = (evt) => {
 				@blur="store.setOne(propName,settings[propName])"/>
 		<NcPasswordField
 				v-else-if="type==='password'"
+				:id="inputId"
 				:label-outside="true"
 				:placeholder="placeholder"
 				class="ps-text-field  ps-vert-spacing"
@@ -89,6 +97,7 @@ const handleFocus = (evt) => {
 				@blur="store.setOne(propName, settings[propName])"/>
 		<NcTextField
 				v-else
+				:id="inputId"
 				:label-outside="true"
 				:placeholder="placeholder"
 				class="ps-text-field  ps-vert-spacing"

--- a/src/components/settings-v2/ComboSelect.vue
+++ b/src/components/settings-v2/ComboSelect.vue
@@ -1,3 +1,7 @@
+<script>
+let idCounter = 0
+</script>
+
 <script setup>
 import LabelAccordion from "../LabelAccordion.vue";
 import PsSelect from "../PsSelect.vue";
@@ -44,6 +48,7 @@ const props = defineProps({
 	}
 })
 
+const inputId = `ps-combo-select-${++idCounter}`
 const isLoading = computed(() => props.store.loading[props.propName] === true)
 const dropdownShouldOpen = computed(() => !(props.clickInterceptor && props.store.k === false))
 
@@ -78,6 +83,7 @@ const handleClick = (evt) => {
 <template>
 	<div>
 		<LabelAccordion
+				:for="inputId"
 				:label="label"
 				:loading="isLoading">
 			<template #helpPopover v-if="slots?.help">
@@ -86,6 +92,8 @@ const handleClick = (evt) => {
 		</LabelAccordion>
 		<PsSelect
 				class="ps-vert-spacing"
+				:input-id="inputId"
+				:aria-label-listbox="label"
 				:placeholder-label="placeholder"
 				:selected-value="store.settings[propName]||defaultValue"
 				:options="options"

--- a/src/components/settings-v2/ComboSelect.vue
+++ b/src/components/settings-v2/ComboSelect.vue
@@ -42,6 +42,11 @@ const props = defineProps({
 		required: false,
 		default: false
 	},
+	required: {
+		type: Boolean,
+		required: false,
+		default: false
+	},
 	clickInterceptor: {
 		type: Function,
 		required: false
@@ -94,6 +99,7 @@ const handleClick = (evt) => {
 				class="ps-vert-spacing"
 				:input-id="inputId"
 				:aria-label-listbox="label"
+				:required="required"
 				:placeholder-label="placeholder"
 				:selected-value="store.settings[propName]||defaultValue"
 				:options="options"

--- a/src/components/settings-v2/SectionAdvancedDebugging.vue
+++ b/src/components/settings-v2/SectionAdvancedDebugging.vue
@@ -79,17 +79,21 @@ const sendUid = () => {
 			{{ t('appointments', 'Settings Dump') }}
 		</NcButton>
 
-		<LabelAccordion :label="t('appointments', 'Get raw calendar data')"/>
+		<LabelAccordion for="ps-debug-get-raw" :label="t('appointments', 'Get raw calendar data')"/>
 		<PsSelect
 				class="ps-vert-spacing"
+				input-id="ps-debug-get-raw"
+				:aria-label-listbox="t('appointments', 'Get raw calendar data')"
 				:placeholder-label="t('appointments', 'Calendar Required')"
 				:selected-value="-1"
 				:options="calendarOptions"
 				@input="(evt)=>{handleAction('get_raw',{p:pageId,cal_id:evt.value})}"/>
 
-		<LabelAccordion :label="t('appointments', 'Sync remote calendar now')"/>
+		<LabelAccordion for="ps-debug-sync" :label="t('appointments', 'Sync remote calendar now')"/>
 		<PsSelect
 				class="ps-vert-spacing"
+				input-id="ps-debug-sync"
+				:aria-label-listbox="t('appointments', 'Sync remote calendar now')"
 				:placeholder-label="t('appointments', 'Calendar Required')"
 				:selected-value="-1"
 				:options="remoteCalendarOptions"

--- a/src/components/settings-v2/SectionCalendars.vue
+++ b/src/components/settings-v2/SectionCalendars.vue
@@ -167,7 +167,7 @@ const handleSetCal = (data) => {
 			<LabelAccordion
 					style="margin-top: .5em"
 					:label="t('appointments', 'Before')"
-					for="ps-buffer-before"/>
+					id="ps-buffer-before-label"/>
 			<vue-slider
 					:min="0"
 					:max="120"
@@ -177,14 +177,14 @@ const handleSetCal = (data) => {
 					tooltip="always"
 					tooltipPlacement="right"
 					:tooltip-formatter="'{value} '+minute"
-					id="ps-buffer-before"
+					:dot-attrs="{'aria-labelledby': 'ps-buffer-before-label'}"
 					class="ps-slider"
 					:value="settings.bufferBefore"
 					@change="(value)=>{settingsStore.setOne('bufferBefore',value)}"/>
 			<LabelAccordion
 					style="margin-top: .5em"
 					:label="t('appointments', 'After')"
-					for="ps-buffer-after"/>
+					id="ps-buffer-after-label"/>
 			<vue-slider
 					:min="0"
 					:max="120"
@@ -194,7 +194,7 @@ const handleSetCal = (data) => {
 					tooltip="always"
 					tooltipPlacement="right"
 					:tooltip-formatter="'{value} '+minute"
-					id="ps-buffer-after"
+					:dot-attrs="{'aria-labelledby': 'ps-buffer-after-label'}"
 					class="ps-slider"
 					:value="settings.bufferBefore"
 					@change="(value)=>{settingsStore.setOne('bufferBefore',value)}"/>

--- a/src/components/settings-v2/SectionCalendarsExternal.vue
+++ b/src/components/settings-v2/SectionCalendarsExternal.vue
@@ -14,6 +14,7 @@ const settingsStore = useSettingsStore()
 	<div>
 		<ComboSelect
 				prop-name="nrSrcCalId"
+				:required="true"
 				:options="calendarOptions"
 				:store="settingsStore"
 				:label="t('appointments', 'Source Calendar (Free Slots)')"
@@ -28,6 +29,7 @@ const settingsStore = useSettingsStore()
 
 		<ComboSelect
 				prop-name="nrDstCalId"
+				:required="true"
 				:options="calendarOptions"
 				:store="settingsStore"
 				:label="t('appointments', 'Destination Calendar (Booked)')"

--- a/src/components/settings-v2/SectionCalendarsSimple.vue
+++ b/src/components/settings-v2/SectionCalendarsSimple.vue
@@ -214,6 +214,7 @@ const showSimpleEditor = () => {
 	<div>
 		<ComboSelect
 				prop-name="mainCalId"
+				:required="true"
 				:options="calendarOptions"
 				:store="settingsStore"
 				:label="t('appointments', 'Main calendar')"
@@ -225,6 +226,7 @@ const showSimpleEditor = () => {
 		</ComboSelect>
 		<ComboSelect
 				prop-name="destCalId"
+				:required="true"
 				:options="calendarOptions"
 				:store="settingsStore"
 				:label="t('appointments', 'Calendar for booked appointments')"

--- a/src/components/settings-v2/SectionCalendarsSimple.vue
+++ b/src/components/settings-v2/SectionCalendarsSimple.vue
@@ -1,12 +1,11 @@
 <script setup>
-import {reactive, inject} from "vue";
+import {computed, reactive, inject} from "vue";
 import LabelAccordion from "../LabelAccordion.vue";
 import IconCalendarAdd from "vue-material-design-icons/CalendarPlus.vue";
 import {useSettingsStore} from "../../stores/settings";
-import DatePicker from "vue2-datepicker";
 import VueSlider from "vue-slider-component";
 import {getTimezone} from "../../use/utils";
-import {NcButton, NcCheckboxRadioSwitch} from "@nextcloud/vue";
+import {NcButton, NcCheckboxRadioSwitch, NcDateTimePickerNative} from "@nextcloud/vue";
 import {showError} from "@nextcloud/dialogs";
 import ComboSelect from "./ComboSelect.vue";
 
@@ -39,47 +38,19 @@ const state = reactive({
 
 // add new ----------------
 
-// TODO: refactor SEF
-const lang = (() => {
-	let days = undefined
-	let months = undefined
-	const formatLocale = {
-		// 1 (Mon) = default/fallback, or 0 (Sun) or 6 (Sat)
-		firstDayOfWeek: window.firstDay === 0
-				? 0
-				: (window.firstDay === 6 ? 6 : 1)
-	}
-	if (window.Intl && typeof window.Intl === "object") {
-		days = []
-		let d = new Date(1970, 1, 1)
-		let f = new Intl.DateTimeFormat([],
-				{weekday: "short",})
-		for (let i = 1; i < 8; i++) {
-			d.setDate(i)
-			days[i - 1] = f.format(d)
-		}
-		f = new Intl.DateTimeFormat([],
-				{month: "short",})
-		d.setDate(1)
-		months = []
-		for (let i = 0; i < 12; i++) {
-			d.setMonth(i)
-			months[i] = f.format(d)
-		}
-		formatLocale.monthsShort = months
-	}
-	return {days: days, formatLocale: formatLocale}
-})()
+// 1 (Mon) = default/fallback, or 0 (Sun) or 6 (Sat)
+const firstDayOfWeek = window.firstDay === 0
+		? 0
+		: (window.firstDay === 6 ? 6 : 1)
 
 const getStartOfWeek = (d) => {
 
 	d.setHours(0, 0, 0, 0)
 
-	// lang.formatLocale.firstDayOfWeek can be:
 	//  0: Sunday
 	//  1: Monday
 	//  6: Saturday
-	const fdw = lang.formatLocale.firstDayOfWeek
+	const fdw = firstDayOfWeek
 
 	//  fdw=0 : 0 1 2 3 4 5 6 | adjust: d.getDay()
 	//  fdw=1 : 1 2 3 4 5 6 0 | adjust: (d.getDay() + 6) % 7
@@ -107,33 +78,28 @@ const compNotBefore = (d) => {
 	return d < notBeforeDate
 }
 
-const datePickerPopupStyle = {
-	top: "75%",
-	left: "50% !important",
-	transform: "translate(-50%,0)"
-}
+// any selected date counts for its whole week
+const apptWeekStart = computed(() => state.apptWeek === null
+		? null
+		: getStartOfWeek(new Date(state.apptWeek.getTime())))
 
-const weekFormat = {
-	// Date to String
-	stringify: (date, fmt) => {
-		if (date) {
-			const endDate = new Date(date.getTime())
-			endDate.setDate(endDate.getDate() + 6);
-			if (window.Intl && typeof window.Intl === "object") {
-				let f = new Intl.DateTimeFormat([],
-						{month: "short", day: "2-digit",})
-				return f.format(date) + ' - ' + f.format(endDate)
-			} else {
-				return date.toLocaleDateString() + ' - ' + (endDate).toLocaleDateString()
-			}
-		} else return ''
+const weekRange = computed(() => {
+	const startDate = apptWeekStart.value
+	if (startDate === null) {
+		return ''
 	}
-}
-const setToStartOfWeek = () => {
-	if (state.apptWeek !== null) {
-		state.apptWeek = getStartOfWeek(state.apptWeek)
+	const endDate = new Date(startDate.getTime())
+	endDate.setDate(endDate.getDate() + 6)
+	if (window.Intl && typeof window.Intl === "object") {
+		const f = new Intl.DateTimeFormat([],
+				{month: "short", day: "2-digit",})
+		return f.format(startDate) + ' - ' + f.format(endDate)
 	}
-}
+	return startDate.toLocaleDateString() + ' - ' + endDate.toLocaleDateString()
+})
+
+const weekInvalid = computed(() => state.apptWeek === null
+		|| compNotBefore(new Date(state.apptWeek.getTime())))
 
 const addAccordionOpen = () => {
 	state.tzLoading = true
@@ -168,7 +134,7 @@ const showSimpleEditor = () => {
 
 	const r = {
 		tz: state.tzData,
-		week: state.apptWeek.getTime(),
+		week: apptWeekStart.value.getTime(),
 		dur: state.apptDur,
 		pageId: pageId,
 		calColor: cal.color,
@@ -255,22 +221,19 @@ const showSimpleEditor = () => {
 			<template v-else-if="state.tzName!==''">
 				<LabelAccordion
 						:label="t('appointments', 'Select Dates')"/>
-				<DatePicker
-						style="width: auto; min-width: 21em;"
-						:editable="false"
-						:disabled-date="compNotBefore"
-						:appendToBody="false"
-						:popup-style="datePickerPopupStyle"
-						:placeholder="t('appointments','Select Dates')"
-						v-model="state.apptWeek"
-						:lang="lang"
-						@input="setToStartOfWeek"
-						:formatter="weekFormat"
-						type="week"></DatePicker>
+				<NcDateTimePickerNative
+						id="ps-simple-week"
+						:label="t('appointments','Select Dates')"
+						:hide-label="true"
+						:min="notBeforeDate"
+						v-model="state.apptWeek"/>
+				<div class="srgdev-appt-info-lcont srgdev-appt-tz-cont" aria-live="polite">
+					{{ weekRange }}
+				</div>
 				<div class="srgdev-appt-info-lcont srgdev-appt-tz-cont">
 					{{ t('appointments', 'Time zone:') + ' ' + state.tzName }}
 				</div>
-				<label for="appt_dur-select" class="select-label">{{ t('appointments', 'Appointment Duration:') }}</label>
+				<label id="ps-appt-dur-label" class="select-label">{{ t('appointments', 'Appointment Duration:') }}</label>
 				<vue-slider
 						:min="5"
 						:max="120"
@@ -278,12 +241,12 @@ const showSimpleEditor = () => {
 						tooltip="always"
 						tooltipPlacement="bottom"
 						:tooltip-formatter="'{value} Min'"
-						id="appt_dur-select"
+						:dot-attrs="{'aria-labelledby': 'ps-appt-dur-label'}"
 						class="appt-slider"
 						v-model="state.apptDur"/>
 				<NcButton
 						@click="showSimpleEditor"
-						:disabled="state.apptWeek===null"
+						:disabled="weekInvalid"
 						style="margin-top: 3.5em;margin-bottom: 2em;padding-left: 3em;padding-right: 3em;"
 						class="srgdev-appt-sb-genbtn"
 						:aria-label="t('appointments', 'Start')">

--- a/src/components/settings-v2/SectionCalendarsWeekly.vue
+++ b/src/components/settings-v2/SectionCalendarsWeekly.vue
@@ -108,6 +108,7 @@ const handleEditTemplate = () => {
 	<div>
 		<ComboSelect
 				prop-name="tmmDstCalId"
+				:required="true"
 				:options="calendarOptions"
 				:store="settingsStore"
 				:label="t('appointments','Destination calendar (Booked)')"

--- a/src/components/settings-v2/SectionEmail.vue
+++ b/src/components/settings-v2/SectionEmail.vue
@@ -50,12 +50,13 @@ const cancelPendingOptions = [
 			</template>
 		</ComboCheckbox>
 		<LabelAccordion
+				id="ps-email-attendee-label"
 				:label="t('appointments','Email Attendee when the appointment is:')">
 			<template #helpPopover>
 				{{ t('appointments', 'Attendees will be notified via email when their upcoming appointments are updated or deleted in the calendar app or through some other external mechanism. Only changes to Date/Time, Status, or Location will trigger the "Modified" notification.') }}
 			</template>
 		</LabelAccordion>
-		<div class="srgdev-appt-sb-indent">
+		<div class="srgdev-appt-sb-indent" role="group" aria-labelledby="ps-email-attendee-label">
 			<ComboCheckbox
 					prop-name="attMod"
 					:label="t('appointments', 'Modified (Time, Status, Location)')"
@@ -66,12 +67,13 @@ const cancelPendingOptions = [
 					:store="settingsStore"/>
 		</div>
 		<LabelAccordion
+				id="ps-email-me-label"
 				:label="t('appointments','Email Me when an appointment is:')">
 			<template #helpPopover>
 				{{ t('appointments', 'A notification email will be sent to you when an appointment is booked via the public page or when an upcoming appointment is confirmed or canceled through the email links.') }}
 			</template>
 		</LabelAccordion>
-		<div class="srgdev-appt-sb-indent">
+		<div class="srgdev-appt-sb-indent" role="group" aria-labelledby="ps-email-me-label">
 			<ComboCheckbox
 					prop-name="meReq"
 					:label="t('appointments', 'Requested')"

--- a/src/components/settings-v2/SectionPageFormEditor.vue
+++ b/src/components/settings-v2/SectionPageFormEditor.vue
@@ -66,6 +66,7 @@ const handleBlur = () => {
 <template>
 	<div>
 		<LabelAccordion
+				for="ps-form-extra-fields"
 				:label="t('appointments','Extra Fields (JSON Object)')"
 				:loading="isLoading">
 			<template #helpPopover>
@@ -74,6 +75,7 @@ const handleBlur = () => {
 			</template>
 		</LabelAccordion>
 		<textarea
+				id="ps-form-extra-fields"
 				placeholder="[{...}]"
 				class="ps-textarea ps-vert-spacing"
 				v-model="model"

--- a/src/components/settings-v2/SettingsDir.vue
+++ b/src/components/settings-v2/SettingsDir.vue
@@ -63,6 +63,7 @@ const deleteDirItem = (deleteIndex) => {
 				<div v-for="(item,index) in settingsStore.dirSettings.dirItems" class="srgdev-appt-dir-pl">
 					<NcActions
 							:disabled="settingsStore.loading[LOADING_DIR]===true"
+							:aria-label="item.title || undefined"
 							menuAlign="right"
 							style="position: absolute"
 							class="srgdev-appt-dir-pl_actions">

--- a/src/components/views/TimeSlotEditor.vue
+++ b/src/components/views/TimeSlotEditor.vue
@@ -26,6 +26,7 @@ const store = useSettingsStore()
 const settings = store.settings
 
 const grid_cont = ref(null)
+const root = ref(null)
 
 /**
  * data is only set for Simple editor (in weekly template mode data is {})
@@ -130,7 +131,10 @@ onMounted(() => {
 			editor.loading = false
 		})
 	}
-	nextTick(gridMaker.scrollGridToTopElm)
+	nextTick(() => {
+		gridMaker.scrollGridToTopElm()
+		root.value.querySelector('button')?.focus()
+	})
 })
 
 const close = () => {
@@ -216,7 +220,7 @@ const gridApptsCopy = (index) => {
 </script>
 
 <template>
-	<div class="srgdev-appt-grid-flex">
+	<div class="srgdev-appt-grid-flex" ref="root">
 		<div v-show="gridMode===gridMaker.MODE_SIMPLE"
 				 class="srgdev-appt-cal-view-btns">
 			<button @click="handleAddToCalendar" class="primary">
@@ -254,6 +258,8 @@ const gridApptsCopy = (index) => {
 			Loading...
 		</div>
 		<div class="srgdev-appt-grid-flex-lower"
+				 role="region"
+				 :aria-label="t('appointments', 'Appointment slots')"
 				 :class="{'editor-hidden':editor.loading===true}">
 			<ul class="srgdev-appt-grid-header">
 				<li v-for="(hi, index) in editor.header"
@@ -262,6 +268,7 @@ const gridApptsCopy = (index) => {
 					<div class="srgdev-appt-gh-txt">{{ hi.txt }}</div>
 					<NcActions
 							menuAlign="right"
+							:aria-label="hi.txt"
 							:open="editor.menuIndex===index"
 							@open="editor.menuIndex=index"
 							class="srgdev-appt-gh-act1">
@@ -274,6 +281,7 @@ const gridApptsCopy = (index) => {
 							<template #icon>
 								<IconPlus :size="20"/>
 							</template>
+							{{ t('appointments', 'Appointments to add') }}
 						</NcActionInput>
 						<NcActionButton
 								v-else

--- a/src/components/views/TimeSlotEditor.vue
+++ b/src/components/views/TimeSlotEditor.vue
@@ -104,6 +104,7 @@ const editor = reactive({
 onMounted(() => {
 
 	gridMaker.setup(grid_cont.value, COL_COUNT, 'srgdev-appt-grd-')
+	gridMaker.setColumnLabels(editor.header.map(h => h.txt))
 
 	if (gridMode === gridMaker.MODE_TEMPLATE) {
 		gridMaker.addPastAppts(settings.template_data, null, gridShift)

--- a/src/form.js
+++ b/src/form.js
@@ -21,8 +21,17 @@
 		const pso = makePso(f.getAttribute("data-pps"))
 		prefillFields(pso)
 		makeDpu(pso)
-		document.getElementById("srgdev-ncfp_sel-dummy").addEventListener("click", selClick)
-		document.getElementById("srgdev-ncfp_sel-dummy").addEventListener("keyup", function (evt) {
+		const selDummy = document.getElementById("srgdev-ncfp_sel-dummy")
+		selDummy.setAttribute("aria-haspopup", "dialog")
+		selDummy.setAttribute("aria-expanded", "false")
+		selDummy.addEventListener("click", selClick)
+		selDummy.addEventListener("keydown", function (evt) {
+			if (isEnterKey(evt)) {
+				evt.preventDefault()
+				selClick(evt)
+			}
+		})
+		selDummy.addEventListener("keyup", function (evt) {
 			if (isSpaceKey(evt)) {
 				selClick(evt)
 			}
@@ -253,12 +262,15 @@
 			elm = document.getElementById("srgdev-dpu_main-cont")
 		}
 		elm.removeAttribute("data-open")
+		const dummy = document.getElementById("srgdev-ncfp_sel-dummy")
+		dummy.setAttribute("aria-expanded", "false")
+		dummy.focus()
 	}
 
 	function selEscCloseListener(evt) {
 		if (evt.key === "Escape" || evt.key === "Esc" || evt.keyCode === 27) {
 			selClose(null)
-			e.preventDefault()
+			evt.preventDefault()
 		}
 	}
 
@@ -278,6 +290,7 @@
 		let elm = document.getElementById("srgdev-dpu_main-cont")
 		if (elm.getAttribute("data-open") === null) {
 			elm.setAttribute("data-open", '')
+			document.getElementById("srgdev-ncfp_sel-dummy").setAttribute("aria-expanded", "true")
 			document.body.addEventListener("keyup", selEscCloseListener)
 			const curActive = document.getElementById("srgdev-dpu_main-date").curActive
 			if (curActive && curActive.indexOf('e') === -1) {
@@ -323,9 +336,12 @@
 			prevNextDPU(bfCont)
 		}
 
-		document.getElementById('srgdev-dpu_dc' + c)
-			.removeAttribute('data-active');
-		document.getElementById('srgdev-dpu_dc' + n).setAttribute('data-active', '')
+		const prevCell = document.getElementById('srgdev-dpu_dc' + c)
+		prevCell.removeAttribute('data-active')
+		prevCell.setAttribute('aria-pressed', 'false')
+		const curCell = document.getElementById('srgdev-dpu_dc' + n)
+		curCell.setAttribute('data-active', '')
+		curCell.setAttribute('aria-pressed', 'true')
 		this.parentElement.curActive = n
 
 		if (n.slice(-1) === 'e') n = 'e'
@@ -369,6 +385,7 @@
 					elm.appendChild(elm1)
 				}
 				elm.setAttribute("tabindex", "0")
+				elm.setAttribute("role", "button")
 				itemsCont.appendChild(elm)
 			})
 
@@ -446,6 +463,16 @@
 		}
 	}
 
+	function setNavDisabled(elm, disabled) {
+		if (disabled) {
+			elm.setAttribute('disabled', '')
+			elm.setAttribute('aria-disabled', 'true')
+		} else {
+			elm.removeAttribute('disabled')
+			elm.removeAttribute('aria-disabled')
+		}
+	}
+
 	function prevNextDPU(e) {
 		let p
 		// e.target===undefined when we do initial "scroll" @see makeDpu()
@@ -455,26 +482,14 @@
 				if (p.curDP > 0) p.curDP--
 			} else {
 				if (p.curDP < p.maxDP) p.curDP++
-				if (p.curDP === p.maxDP) {
-					e.target.setAttribute('disabled', '')
-				} else {
-					e.target.removeAttribute('disabled')
-				}
+				setNavDisabled(e.target, p.curDP === p.maxDP)
 			}
 		} else {
 			p = e;
 		}
-		if (p.curDP === 0) {
-			p.firstElementChild.setAttribute('disabled', '')
-		} else {
-			p.firstElementChild.removeAttribute('disabled')
-		}
+		setNavDisabled(p.firstElementChild, p.curDP === 0)
 
-		if (p.curDP === p.maxDP) {
-			p.lastElementChild.setAttribute('disabled', '')
-		} else {
-			p.lastElementChild.removeAttribute('disabled')
-		}
+		setNavDisabled(p.lastElementChild, p.curDP === p.maxDP)
 
 		// TODO: find first not empty and select it ?
 
@@ -588,6 +603,10 @@
 
 		const sel = document.createElement('select')
 		sel.id = 'srgdev-dpu_tz-picker'
+		const tzLabel = document.getElementById('srgdev-ncfp_sel-hidden').getAttribute('data-tr-tz')
+		if (tzLabel) {
+			sel.setAttribute('aria-label', tzLabel)
+		}
 
 		sel.addEventListener('change', () => {
 
@@ -705,8 +724,13 @@
 		e1.addEventListener('click', dateClickOrFocus)
 		if (!is_empty) {
 			e1.setAttribute("tabindex", "0")
+			e1.setAttribute('role', 'button')
+			e1.setAttribute('aria-label', formatters.wft(d))
+			e1.setAttribute('aria-pressed', 'false')
 			e1.addEventListener('focus', dateClickOrFocus)
 			e1.addEventListener('keyup', dateKeyboard)
+		} else {
+			e1.setAttribute('aria-hidden', 'true')
 		}
 
 		if (ref.lcc === ref.rccN) {
@@ -859,6 +883,7 @@
 		const dpuTrHdr = s.getAttribute("data-hdr")
 		const dpuTrBack = s.getAttribute("data-tr-back")
 		const dpuTrNext = s.getAttribute("data-tr-next")
+		const dpuTrClose = s.getAttribute("data-tr-close")
 
 		const has_intl = window.Intl && typeof window.Intl === "object"
 		const lang = document.documentElement.hasAttribute('data-locale')
@@ -987,6 +1012,8 @@
 			// first render
 			const cont = document.createElement('div')
 			cont.id = "srgdev-dpu_main-cont"
+			cont.setAttribute('role', 'dialog')
+			cont.setAttribute('aria-label', dpuTrHdr)
 			cont.className = "srgdev-dpu-bkr-cls"
 
 			lcd = document.createElement('div')
@@ -1004,10 +1031,19 @@
 			lcdBF.firstElementChild.id = "srgdev-dpu_bf-back"
 			lcdBF.firstElementChild.appendChild(document.createTextNode(dpuTrBack))
 			lcdBF.firstElementChild.addEventListener("click", prevNextDPU)
-			lcdBF.firstElementChild.setAttribute('disabled', '')
+			setNavDisabled(lcdBF.firstElementChild, true)
 			lcdBF.lastElementChild.id = "srgdev-dpu_bf-next"
 			lcdBF.lastElementChild.appendChild(document.createTextNode(dpuTrNext))
 			lcdBF.lastElementChild.addEventListener("click", prevNextDPU)
+			for (const nav of [lcdBF.firstElementChild, lcdBF.lastElementChild]) {
+				nav.setAttribute('role', 'button')
+				nav.setAttribute('tabindex', '0')
+				nav.addEventListener('keyup', function (evt) {
+					if (isSpaceKey(evt) || isEnterKey(evt)) {
+						this.click()
+					}
+				})
+			}
 			// Time columns
 			if (pso[PPS_TIME2] === 0 || pso[PPS_END_TIME] === 1) {
 				lcdBF.tuClass = 'srgdev-dpu-time-unit' +
@@ -1036,6 +1072,7 @@
 			const btn = document.createElement('div')
 			btn.id = "srgdev-dpu_main-hdr-icon"
 			btn.className = "icon-close"
+			btn.setAttribute('aria-label', dpuTrClose)
 			btn.addEventListener('click', function () {
 				selClose(null)
 			})
@@ -1048,6 +1085,11 @@
 			btn.setAttribute("tabindex", "0")
 			cont.appendChild(btn)
 
+			cont.addEventListener('keydown', function (evt) {
+				if (isSpaceKey(evt) && evt.target.tagName !== 'SELECT') {
+					evt.preventDefault()
+				}
+			})
 			cont.addEventListener("click", timeClick)
 			cont.addEventListener('keyup', function (evt) {
 				if (isSpaceKey(evt) || isEnterKey(evt)) {

--- a/src/grid.js
+++ b/src/grid.js
@@ -47,6 +47,8 @@ function _apptGridMaker() {
 
 		sorted: [],
 
+		colLabels: [],
+
 		mode: MODE_SIMPLE
 	}
 
@@ -209,8 +211,18 @@ function _apptGridMaker() {
 
 		if (idx !== null) {
 
+			elm.tabIndex = 0
+			elm.setAttribute('role', 'slider')
+			elm.setAttribute('aria-orientation', 'vertical')
+			elm.setAttribute('aria-valuemin', '0')
+			if (mData.colLabels[cID] !== undefined) {
+				elm.setAttribute('aria-label', mData.colLabels[cID])
+			}
+			setApptAria(elm)
+
 			// TODO: delegate these events to the parent ???
 			elm.addEventListener("mousedown", appGoDrag)
+			elm.addEventListener("keydown", apptKeydown)
 			if (mData.mode === MODE_TEMPLATE) {
 				elm.addEventListener("contextmenu", editAppt)
 			}
@@ -218,6 +230,64 @@ function _apptGridMaker() {
 
 		}
 		return elm
+	}
+
+	function setApptAria(elm) {
+		elm.setAttribute('aria-valuemax', String(mData.uMax - elm.uLen + 1))
+		elm.setAttribute('aria-valuenow', String(elm.uTop))
+		elm.setAttribute('aria-valuetext', makeTxt(elm) + (elm.title ? ', ' + elm.title : ''))
+	}
+
+	function apptKeydown(evt) {
+		const elm = evt.currentTarget
+
+		if (evt.key === 'Enter') {
+			if (mData.mode === MODE_TEMPLATE) {
+				mData.scrollCont.lastElementChild.dispatchEvent(new CustomEvent('gridContext', {detail: elm}))
+				evt.preventDefault()
+			}
+			return
+		}
+
+		let delta
+		switch (evt.key) {
+			case 'ArrowUp':
+				delta = -1
+				break
+			case 'ArrowDown':
+				delta = 1
+				break
+			case 'PageUp':
+				delta = -12
+				break
+			case 'PageDown':
+				delta = 12
+				break
+			default:
+				return
+		}
+		evt.preventDefault()
+		evt.stopPropagation()
+
+		const uMax = mData.uMax - elm.uLen + 1
+		let idx = elm.uTop + delta
+		if (idx < 0) idx = 0
+		else if (idx > uMax) idx = uMax
+		if (idx === elm.uTop) return
+
+		elm.uTop = idx
+		elm.style.top = mData.elms[idx].offsetTop + 'px'
+		elm.firstElementChild.textContent = makeTxt(elm)
+		setApptAria(elm)
+
+		const colElms = mData.mc_elm[elm.cID]
+		setSorted(colElms, elm)
+		const ts = mData.sorted[colElms.length - 1]
+		ts.h = elm.uTop
+		ts.l = ts.h + elm.uLen
+		setMargins(colElms)
+
+		elm.scrollIntoView({block: 'nearest'})
 	}
 
 	function editAppt(evt) {
@@ -277,6 +347,7 @@ function _apptGridMaker() {
 			}
 		}
 
+		setApptAria(el)
 		setSorted(colElms, el)
 		setMargins(colElms)
 	}
@@ -537,6 +608,7 @@ function _apptGridMaker() {
 			// Set txt
 			de.uTop = idx
 			de.firstElementChild.textContent = makeTxt(de)
+			setApptAria(de)
 			de.style.top = md.elms[idx].offsetTop + 'px'
 		} else {
 			md.ce = null
@@ -546,6 +618,14 @@ function _apptGridMaker() {
 	/**
 	 * @param n number of columns
 	 */
+	function setColumnLabels(labels) {
+		mData.colLabels = labels
+		mData.mc_cols.forEach((col, i) => {
+			col.setAttribute('role', 'group')
+			col.setAttribute('aria-label', labels[i])
+		})
+	}
+
 	function makeColumns(n) {
 		for (let al = mData.apptLayer, elm,
 			     w = getColumnWidth(n), i = 0; i < n; i++) {
@@ -746,6 +826,7 @@ function _apptGridMaker() {
 		resetAllColumns: resetAllColumns,
 		getStarEnds: getStarEnds,
 		addPastAppts: addPastAppts,
+		setColumnLabels: setColumnLabels,
 		setMode: setMode,
 		updateAppt: updateAppt,
 		getTemplateData: getTemplateData,

--- a/templates/public/directory.php
+++ b/templates/public/directory.php
@@ -8,8 +8,8 @@ style('appointments', 'form');
     echo $_['appt_inline_style'];
     foreach ($_['links'] as $link){
       echo '<a href="'.$link['url'].'" target="_blank" class="appt-dir-lnk">'.
-        '<h1 class="appt-dir-lnk_h1">'.$link['title'].'</h1>'.
-          (!empty($link['subTitle'])?'<h2 class="appt-dir-lnk_h2">'.$link['subTitle'].'</h2>':'').
+        '<h2 class="appt-dir-lnk_h1">'.$link['title'].'</h2>'.
+          (!empty($link['subTitle'])?'<h3 class="appt-dir-lnk_h2">'.$link['subTitle'].'</h3>':'').
           (!empty($link['text'])?'<p class="appt-dir-lnk_p">'.$link['text'].'</p>':'').'</a>';
     }
     ?>

--- a/templates/public/form.php
+++ b/templates/public/form.php
@@ -31,7 +31,7 @@ style('appointments', 'form');
             // TRANSLATORS Button: meaning go to next section. Keep short if possible, abbreviations OK
             $next = $l->t('Next');
 
-            echo ' ' . $disabled . 'data-state="' . $_['appt_state'] . '" data-info="' . $_['appt_sel_opts'] . '" data-hdr="' . htmlspecialchars($l->t('Select Date and Time'), ENT_QUOTES, 'UTF-8') . '" data-tr-back="' . htmlspecialchars($back, ENT_QUOTES, 'UTF-8') . '" data-tr-next="' . htmlspecialchars($next, ENT_QUOTES, 'UTF-8') . '" data-tr-not-available="' . htmlspecialchars($l->t('No Appointments Available'), ENT_QUOTES, 'UTF-8') . '">';
+            echo ' ' . $disabled . 'data-state="' . $_['appt_state'] . '" data-info="' . $_['appt_sel_opts'] . '" data-hdr="' . htmlspecialchars($l->t('Select Date and Time'), ENT_QUOTES, 'UTF-8') . '" data-tr-back="' . htmlspecialchars($back, ENT_QUOTES, 'UTF-8') . '" data-tr-next="' . htmlspecialchars($next, ENT_QUOTES, 'UTF-8') . '" data-tr-not-available="' . htmlspecialchars($l->t('No Appointments Available'), ENT_QUOTES, 'UTF-8') . '" data-tr-close="' . htmlspecialchars($l->t('Close'), ENT_QUOTES, 'UTF-8') . '" data-tr-tz="' . htmlspecialchars($l->t('Time zone'), ENT_QUOTES, 'UTF-8') . '">';
             ?>
         </div>
         <?php

--- a/templates/public/thanks.php
+++ b/templates/public/thanks.php
@@ -18,7 +18,7 @@ echo $_['appt_inline_style'];
         echo isset($_['appt_c_more']) ? $_['appt_c_more'] : '';
         if (isset($_['appt_t1'])) { ?>
             <form id="srgdev-appt-cncf_action_frm" data-lbl="<?= $_['appt_cncf_delay'] ?>" method="post">
-                <label class="srgdev-appt-cncf-label"><input name="tos" type="checkbox"/>Agree to TOS</label>
+                <label class="srgdev-appt-cncf-label" aria-hidden="true"><input name="tos" type="checkbox" tabindex="-1"/>Agree to TOS</label>
                 <button id="srgdev-appt-cncf_action_btn"
                         data-t1="<?= $_['appt_t1'] ?>"
                         class="primary srgdev-ncfp-form-btn"


### PR DESCRIPTION
Disclosure: Created carefully with Claude, reviewed by a blind screen reader user. This PR description and any engagement is me, not Claude.

I've had a hard time using this app for a while. Many controls were not labelled or correctly associated with existing labels. Further, I didn't even know there were help popovers, which is part of why I use Claude for this work--SVGs without correct markup for accessibility are literally invisible to me and I wouldn't have even spotted these if the agent hadn't pointed them out.

There are lots of changes here, but most of these compose well and can be individually cherrypicked if desired. I moved through the settings screen control-by-control, ensured that each had a reasonable label/context, did my best to ensure that visual changes were kept to a minimum and verified graphically by Claude, and moved through the workflow of setting up appointments how I'd like to on my live server. The entire process, including adding simple/template slots via the keyboard and picking an appointment time, is now keyboard-accessible and presents nicely to my screen reader.

A few visual edits were needed. First, the datepicker was switched to a native date input because the real fix is needed in an upstream library and I only have so many hours in a day. Hopefully that's OK--Claude claims the diff is minimal and consistent with Nextcloud styling but as a blind user I can't verify that and have to trust the machine. Next, there's what appears to be an anti-bot mechanism in appointment cancellation that honestly feels gross and shouldn't have been done that way at all. It would have flagged me as a bot because the checkbox is visually hidden but still in the tab order and looks like the kind of thing I'd have just checked and moved on past--I don't care about TOS when it comes time to cancel an appointment, would have agreed to it to finish the process, and my appointment wouldn't have been cancelled to everyone's disappointment. This does give bots more signals to glom onto when determining the field's validity, but I'm a bit unclear on the intent and will defer to you. Either way, it should be the kind of thing that can be disabled. As a blind user setting up an appointment page which might be used by other blind folks, an anti-bot TOS agreement that silently drops cancellations is going to cause everyone lots of grief.

With this PR in place, I'm able to set up my appointment page how I wanted, and to book an appointment using the public form. Before, I struggled hard to set things up correctly and was unable to set slots or a template.

Thanks a bunch, please let me know if you'd like any changes.