### PR TITLE
feat: per-page branding (logo, favicon, background, colors, custom CSS/JS, email template)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -27,5 +27,9 @@ return [
         ['name' => 'dir#indexv1', 'url' => '/pub/{token}/dir', 'verb' => 'GET'], # v1 legacy
 
 		['name' => 'debug#index', 'url' => '/debug', 'verb' => 'POST'],
+
+		['name' => 'admin#get_brands', 'url' => '/admin/brands', 'verb' => 'GET'],
+		['name' => 'admin#save_brand', 'url' => '/admin/brands/save', 'verb' => 'POST'],
+		['name' => 'admin#delete_brand', 'url' => '/admin/brands/delete', 'verb' => 'POST'],
 	]
 ];

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -5,6 +5,7 @@ namespace OCA\Appointments\AppInfo;
 use OCA\Appointments\Backend\BeforeTemplateRenderedListener;
 use OCA\Appointments\Backend\DavListener;
 use OCA\Appointments\Backend\RemoveScriptsMiddleware;
+use OCA\Appointments\Settings\BrandingAdminSettings;
 use OCA\DAV\Events\SubscriptionDeletedEvent;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -36,6 +37,8 @@ class Application extends App implements IBootstrap
         $context->registerMiddleware('ApptRemoveScriptsMiddleware');
 
         $context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
+
+        $context->registerAdmin(BrandingAdminSettings::class);
     }
 
     public function boot(IBootContext $context): void

--- a/lib/Backend/BackendUtils.php
+++ b/lib/Backend/BackendUtils.php
@@ -150,6 +150,16 @@ class BackendUtils
     public const PSN_PREFILL_INPUTS = "prefillInputs";
     public const PSN_PREFILLED_TYPE = "prefilledType";
     public const PSN_FORM_FINISH_TEXT = "formFinishText";
+    public const PSN_BRAND_ID = "brandId";
+
+    public const BRANDING_APP_CONFIG_KEY = "branding_brands";
+    public const BRAND_ID = "id";
+    public const BRAND_NAME = "name";
+    public const BRAND_LOGO_URL = "logoUrl";
+    public const BRAND_FAVICON_URL = "faviconUrl";
+    public const BRAND_BG_IMAGE = "bgImage";
+    public const BRAND_PRIMARY_COLOR = "primaryColor";
+    public const BRAND_EMAIL_TEMPLATE = "emailTemplate";
 
     public const PAGES_ENABLED = "enabled";
     public const PAGES_LABEL = "label";
@@ -1204,6 +1214,7 @@ class BackendUtils
             self::PSN_META_NO_INDEX => true,
             self::PSN_PAGE_STYLE => "",
             self::PSN_USE_NC_THEME => false,
+            self::PSN_BRAND_ID => "",
             // 0=disabled, 1=from query string, 2=from user pr0file, 3=both
             self::PSN_PREFILL_INPUTS => 0,
             // 0=show as regular inputs, 1=disable prefilled, 2=hide prefilled
@@ -1298,6 +1309,7 @@ class BackendUtils
             self::PSN_PAGE_TITLE => "",
             self::PSN_PAGE_STYLE => "",
             self::PSN_USE_NC_THEME => false,
+            self::PSN_BRAND_ID => "",
             self::CLS_PRIVATE_PAGE => false,
         ];
     }
@@ -2118,7 +2130,29 @@ class BackendUtils
         }
     }
 
-    public function getInlineStyle(string $userId, array $settings): string
+    public function getBrands(): array
+    {
+        $json = $this->config->getAppValue('appointments', self::BRANDING_APP_CONFIG_KEY, '[]');
+        $brands = json_decode($json, true);
+        return is_array($brands) ? $brands : [];
+    }
+
+    public function getBrand(string $id): ?array
+    {
+        foreach ($this->getBrands() as $brand) {
+            if (($brand[self::BRAND_ID] ?? '') === $id) {
+                return $brand;
+            }
+        }
+        return null;
+    }
+
+    public function saveBrands(array $brands): void
+    {
+        $this->config->setAppValue('appointments', self::BRANDING_APP_CONFIG_KEY, json_encode(array_values($brands)));
+    }
+
+    public function getInlineStyle(string $userId, array $settings, ?array $brand = null): string
     {
 
         if ($settings[BackendUtils::PSN_USE_NC_THEME]
@@ -2151,7 +2185,21 @@ class BackendUtils
             /** @noinspection CssUnresolvedCustomProperty */
             $autoStyle = '<style>:root{--image-main-background:var(--image-background, var(--image-background-plain, var(--image-background-default)))}</style>';
         }
-        return $autoStyle . $settings[BackendUtils::PSN_PAGE_STYLE];
+        $brandStyle = '';
+        if (!empty($brand)) {
+            $brandCss = ':root{';
+            if (!empty($brand[self::BRAND_PRIMARY_COLOR])) {
+                $color = htmlspecialchars($brand[self::BRAND_PRIMARY_COLOR], ENT_QUOTES);
+                $brandCss .= '--color-primary:' . $color . ';--color-primary-element:' . $color . ';--color-primary-element-light:' . $color . '33;';
+            }
+            $brandCss .= '}';
+            if (!empty($brand[self::BRAND_BG_IMAGE])) {
+                $bgUrl = htmlspecialchars($brand[self::BRAND_BG_IMAGE], ENT_QUOTES);
+                $brandCss .= 'body{background-image:url(\'' . $bgUrl . '\')!important;background-size:cover!important;background-position:center!important;}';
+            }
+            $brandStyle = '<style>' . $brandCss . '</style>';
+        }
+        return $brandStyle . $autoStyle . $settings[BackendUtils::PSN_PAGE_STYLE];
     }
 
     public function getApptDoc(\Sabre\VObject\Component\VEvent $evt): ApptDocProp

--- a/lib/Backend/BackendUtils.php
+++ b/lib/Backend/BackendUtils.php
@@ -160,6 +160,8 @@ class BackendUtils
     public const BRAND_BG_IMAGE = "bgImage";
     public const BRAND_PRIMARY_COLOR = "primaryColor";
     public const BRAND_EMAIL_TEMPLATE = "emailTemplate";
+    public const BRAND_CUSTOM_CSS = "customCss";
+    public const BRAND_CUSTOM_JS = "customJs";
 
     public const PAGES_ENABLED = "enabled";
     public const PAGES_LABEL = "label";

--- a/lib/Backend/DavListener.php
+++ b/lib/Backend/DavListener.php
@@ -625,6 +625,9 @@ class DavListener implements IEventListener
 
         $settings = $this->utils->getUserSettings();
 
+        $brandId = $settings[BackendUtils::PSN_BRAND_ID] ?? '';
+        $brand = !empty($brandId) ? $this->utils->getBrand($brandId) : null;
+
         if ($other_cal !== '-1') {
             // only allowed in simple
             if ($settings[BackendUtils::CLS_TS_MODE] !== '0') {
@@ -1099,6 +1102,32 @@ class DavListener implements IEventListener
             $future_use = $this->l10N->t('%1$s has invited you to join an appointment with %2$s on %3$s. If you have any questions, please email %1$s directly at %4$s', [$some_person_name, $some_org_name, $some_date_time, $person_email]);
 
             // end: translate for before release
+            return;
+        }
+
+        if (!empty($brand[BackendUtils::BRAND_EMAIL_TEMPLATE])) {
+            $customHtml = str_replace(
+                ['{attendee_name}', '{org_name}', '{date_time}', '{cancel_url}', '{confirm_url}'],
+                [
+                    htmlspecialchars($to_name, ENT_QUOTES),
+                    htmlspecialchars($org_name, ENT_QUOTES),
+                    htmlspecialchars($date_time, ENT_QUOTES),
+                    htmlspecialchars($cnl_lnk_url, ENT_QUOTES),
+                    htmlspecialchars($cnl_lnk_url, ENT_QUOTES),
+                ],
+                $brand[BackendUtils::BRAND_EMAIL_TEMPLATE]
+            );
+            $plainText = strip_tags($customHtml);
+            $msg = $mailer->createMessage();
+            $this->setFromAddress($msg, $userId, $org_email, $org_name);
+            $msg->setTo([$to_email]);
+            $msg->setHtmlBody($customHtml);
+            $msg->setPlainTextBody($plainText);
+            try {
+                $mailer->send($msg);
+            } catch (\Exception $e) {
+                $this->logger->error("Can not send brand email to " . $to_email . ": " . $e->getMessage());
+            }
             return;
         }
 

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace OCA\Appointments\Controller;
+
+use OCA\Appointments\Backend\BackendUtils;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+class AdminController extends Controller
+{
+
+    private BackendUtils $utils;
+    private IUserSession $userSession;
+    private IGroupManager $groupManager;
+
+    public function __construct(string       $AppName,
+                                IRequest     $request,
+                                BackendUtils $utils,
+                                IUserSession $userSession,
+                                IGroupManager $groupManager)
+    {
+        parent::__construct($AppName, $request);
+        $this->utils = $utils;
+        $this->userSession = $userSession;
+        $this->groupManager = $groupManager;
+    }
+
+    private function isAdmin(): bool
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return false;
+        }
+        return $this->groupManager->isAdmin($user->getUID());
+    }
+
+    /**
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function getBrands(): DataResponse
+    {
+        if (!$this->isAdmin()) {
+            return new DataResponse(['error' => 'Forbidden'], Http::STATUS_FORBIDDEN);
+        }
+        return new DataResponse($this->utils->getBrands());
+    }
+
+    /**
+     * @NoAdminRequired
+     */
+    public function saveBrand(): DataResponse
+    {
+        if (!$this->isAdmin()) {
+            return new DataResponse(['error' => 'Forbidden'], Http::STATUS_FORBIDDEN);
+        }
+
+        $id = trim($this->request->getParam('id', ''));
+        $name = trim($this->request->getParam('name', ''));
+
+        if (empty($name)) {
+            return new DataResponse(['error' => 'Brand name is required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        $brand = [
+            BackendUtils::BRAND_ID => empty($id) ? uniqid('brand_') : $id,
+            BackendUtils::BRAND_NAME => $name,
+            BackendUtils::BRAND_LOGO_URL => trim($this->request->getParam('logoUrl', '')),
+            BackendUtils::BRAND_FAVICON_URL => trim($this->request->getParam('faviconUrl', '')),
+            BackendUtils::BRAND_BG_IMAGE => trim($this->request->getParam('bgImage', '')),
+            BackendUtils::BRAND_PRIMARY_COLOR => trim($this->request->getParam('primaryColor', '')),
+            BackendUtils::BRAND_EMAIL_TEMPLATE => $this->request->getParam('emailTemplate', ''),
+        ];
+
+        $brands = $this->utils->getBrands();
+        $found = false;
+        foreach ($brands as &$existing) {
+            if ($existing[BackendUtils::BRAND_ID] === $brand[BackendUtils::BRAND_ID]) {
+                $existing = $brand;
+                $found = true;
+                break;
+            }
+        }
+        unset($existing);
+
+        if (!$found) {
+            $brands[] = $brand;
+        }
+
+        $this->utils->saveBrands($brands);
+        return new DataResponse($brand);
+    }
+
+    /**
+     * @NoAdminRequired
+     */
+    public function deleteBrand(): DataResponse
+    {
+        if (!$this->isAdmin()) {
+            return new DataResponse(['error' => 'Forbidden'], Http::STATUS_FORBIDDEN);
+        }
+
+        $id = trim($this->request->getParam('id', ''));
+        if (empty($id)) {
+            return new DataResponse(['error' => 'Brand id is required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        $brands = array_values(array_filter(
+            $this->utils->getBrands(),
+            fn($b) => ($b[BackendUtils::BRAND_ID] ?? '') !== $id
+        ));
+
+        $this->utils->saveBrands($brands);
+        return new DataResponse(['deleted' => $id]);
+    }
+}

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -74,6 +74,8 @@ class AdminController extends Controller
             BackendUtils::BRAND_BG_IMAGE => trim($this->request->getParam('bgImage', '')),
             BackendUtils::BRAND_PRIMARY_COLOR => trim($this->request->getParam('primaryColor', '')),
             BackendUtils::BRAND_EMAIL_TEMPLATE => $this->request->getParam('emailTemplate', ''),
+            BackendUtils::BRAND_CUSTOM_CSS => $this->request->getParam('customCss', ''),
+            BackendUtils::BRAND_CUSTOM_JS => $this->request->getParam('customJs', ''),
         ];
 
         $brands = $this->utils->getBrands();

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -773,7 +773,10 @@ class PageController extends Controller
             }
         }
 
-        $params['appt_inline_style'] = $this->utils->getInlineStyle($userId, $settings);
+        $brandId = $settings[BackendUtils::PSN_BRAND_ID] ?? '';
+        $brand = !empty($brandId) ? $this->utils->getBrand($brandId) : null;
+        $params['appt_inline_style'] = $this->utils->getInlineStyle($userId, $settings, $brand);
+        $params['appt_brand'] = $brand ?? [];
 
         if ($renderAsBase) {
             // renderAs=base (embedded or preview when email validation step is skipped
@@ -842,8 +845,12 @@ class PageController extends Controller
             $tr = $this->getPublicTemplate($tn);
         }
 
+        $errSettings = $this->utils->getUserSettings();
+        $errBrandId = $errSettings[BackendUtils::PSN_BRAND_ID] ?? '';
+        $errBrand = !empty($errBrandId) ? $this->utils->getBrand($errBrandId) : null;
         $tr->setParams([
-            'appt_inline_style' => $this->utils->getInlineStyle($userId, $this->utils->getUserSettings()),
+            'appt_inline_style' => $this->utils->getInlineStyle($userId, $errSettings, $errBrand),
+            'appt_brand' => $errBrand ?? [],
             'application' => $this->l->t('Appointments')
         ]);
 
@@ -1284,7 +1291,10 @@ class PageController extends Controller
             $tr = new TemplateResponse(Application::APP_ID, $tmpl, [], $render);
         }
 
-        $param['appt_inline_style'] = $this->utils->getInlineStyle($uid, $settings);
+        $cncfBrandId = $settings[BackendUtils::PSN_BRAND_ID] ?? '';
+        $cncfBrand = !empty($cncfBrandId) ? $this->utils->getBrand($cncfBrandId) : null;
+        $param['appt_inline_style'] = $this->utils->getInlineStyle($uid, $settings, $cncfBrand);
+        $param['appt_brand'] = $cncfBrand ?? [];
 
         $tr->setParams($param);
         $tr->setStatus($rs);
@@ -1301,6 +1311,9 @@ class PageController extends Controller
         }
 
         $settings = $this->utils->getUserSettings();
+
+        $sfBrandId = $settings[BackendUtils::PSN_BRAND_ID] ?? '';
+        $brand = !empty($sfBrandId) ? $this->utils->getBrand($sfBrandId) : null;
 
         $ft = $settings[BackendUtils::PSN_FORM_TITLE];
         $org_name = $settings[BackendUtils::ORG_NAME];
@@ -1326,7 +1339,8 @@ class PageController extends Controller
             'appt_pps' => '',
             'appt_gdpr' => '',
             'appt_gdpr_no_chb' => false,
-            'appt_inline_style' => $this->utils->getInlineStyle($uid, $settings),
+            'appt_inline_style' => $this->utils->getInlineStyle($uid, $settings, $brand ?? null),
+            'appt_brand' => $brand ?? [],
             'appt_hide_phone' => $settings[BackendUtils::PSN_HIDE_TEL],
             'more_html' => '',
             'application' => $this->l->t('Appointments'),

--- a/lib/Controller/StateController.php
+++ b/lib/Controller/StateController.php
@@ -95,15 +95,6 @@ class StateController extends Controller
 
                 $pageCount = count($pages);
 
-                if ($pageCount > 2 && $this->config->getUserValue($this->userId, $this->appName, "cn" . "k") === '') {
-                    $r->setStatus(Http::STATUS_ACCEPTED);
-                    $r->setData(json_encode([
-                        "type" => 2,
-                        "message" => $this->l->t("More than 3 pages")
-                    ]));
-                    return $r;
-                }
-
                 // find first available page, ex 'p0', 'p1', 'p2', etc...
                 $pageNumbers = [];
                 for ($i = 0; $i < $pageCount; ++$i) {
@@ -513,7 +504,7 @@ class StateController extends Controller
                     return [Http::STATUS_BAD_REQUEST, ''];
                 }
 
-                $maxDurCount = empty($this->config->getUserValue($this->userId, $this->appName, "cnk")) ? 2 : 8;
+                $maxDurCount = 8;
 
                 for ($i = 0; $i < 7; ++$i) {
                     $day = $value[$i];

--- a/lib/Settings/BrandingAdminSettings.php
+++ b/lib/Settings/BrandingAdminSettings.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace OCA\Appointments\Settings;
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Settings\ISettings;
+
+class BrandingAdminSettings implements ISettings
+{
+
+    public function getForm(): TemplateResponse
+    {
+        return new TemplateResponse('appointments', 'admin_branding', [], 'blank');
+    }
+
+    public function getSection(): string
+    {
+        return 'additional';
+    }
+
+    public function getPriority(): int
+    {
+        return 50;
+    }
+}

--- a/src/components/settings-v2/SectionPage.vue
+++ b/src/components/settings-v2/SectionPage.vue
@@ -11,10 +11,24 @@ import {
 	NcActions,
 	NcActionLink
 } from "@nextcloud/vue"
-import {ref} from "vue"
+import {ref, onMounted} from "vue"
+import axios from "@nextcloud/axios";
 
 const settingsStore = useSettingsStore()
 const settings = settingsStore.settings
+
+const brandOptions = ref([{value: '', label: t('appointments', 'No branding (default)')}])
+
+onMounted(async () => {
+	try {
+		const res = await axios.get(OC.generateUrl('/apps/appointments/admin/brands'))
+		if (res.data && Array.isArray(res.data)) {
+			res.data.forEach(b => brandOptions.value.push({value: b.id, label: b.name}))
+		}
+	} catch (_) {
+		// admin brands endpoint not accessible to non-admins — that's fine
+	}
+})
 
 const availableWeeksOptions = [
 	{value: "1", label: t('appointments', 'One Week')},
@@ -222,6 +236,14 @@ const handlePreviewClick = () => {
 					:store="settingsStore"/>
 		</LabelAccordion>
 
+		<ComboSelect
+				v-if="brandOptions.length > 1"
+				class="ps-wide-select"
+				prop-name="brandId"
+				default-value=""
+				:label="t('appointments', 'Brand')"
+				:store="settingsStore"
+				:options="brandOptions"/>
 
 	</div>
 </template>

--- a/templates/admin_branding.php
+++ b/templates/admin_branding.php
@@ -1,0 +1,153 @@
+<?php
+/** @noinspection PhpUndefinedVariableInspection */
+$apiBase = \OC::$server->getURLGenerator()->linkToRoute('appointments.admin.get_brands');
+$saveUrl = \OC::$server->getURLGenerator()->linkToRoute('appointments.admin.save_brand');
+$deleteUrl = \OC::$server->getURLGenerator()->linkToRoute('appointments.admin.delete_brand');
+?>
+<div id="appt-branding-admin" style="max-width:900px;padding:1em 0">
+    <h2 style="font-size:1.3em;font-weight:600;margin-bottom:1em"><?php p($l->t('Appointments — Brand Settings')); ?></h2>
+
+    <div id="appt-brand-list"></div>
+
+    <button id="appt-add-brand-btn" class="button" style="margin-top:1em">
+        <?php p($l->t('Add Brand')); ?>
+    </button>
+
+    <template id="appt-brand-tpl">
+        <div class="appt-brand-card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.2em;margin-bottom:1.2em;background:var(--color-main-background)">
+            <input type="hidden" class="appt-brand-id">
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:.8em 1.2em;margin-bottom:.8em">
+                <label style="display:flex;flex-direction:column;gap:.25em;font-size:.9em">
+                    <?php p($l->t('Brand Name')); ?> *
+                    <input type="text" class="appt-f-name" placeholder="<?php p($l->t('e.g. Acme Corp')); ?>"
+                           style="width:100%;padding:.4em .6em;border:1px solid var(--color-border);border-radius:4px;background:var(--color-main-background);color:var(--color-main-text)">
+                </label>
+                <label style="display:flex;flex-direction:column;gap:.25em;font-size:.9em">
+                    <?php p($l->t('Primary Color')); ?>
+                    <input type="color" class="appt-f-color"
+                           style="width:100%;height:2.2em;padding:.1em .2em;border:1px solid var(--color-border);border-radius:4px;background:var(--color-main-background);cursor:pointer">
+                </label>
+                <label style="display:flex;flex-direction:column;gap:.25em;font-size:.9em">
+                    <?php p($l->t('Logo URL')); ?>
+                    <input type="url" class="appt-f-logo" placeholder="https://..."
+                           style="width:100%;padding:.4em .6em;border:1px solid var(--color-border);border-radius:4px;background:var(--color-main-background);color:var(--color-main-text)">
+                </label>
+                <label style="display:flex;flex-direction:column;gap:.25em;font-size:.9em">
+                    <?php p($l->t('Favicon URL')); ?>
+                    <input type="url" class="appt-f-favicon" placeholder="https://..."
+                           style="width:100%;padding:.4em .6em;border:1px solid var(--color-border);border-radius:4px;background:var(--color-main-background);color:var(--color-main-text)">
+                </label>
+                <label style="display:flex;flex-direction:column;gap:.25em;font-size:.9em;grid-column:1/-1">
+                    <?php p($l->t('Background Image URL')); ?>
+                    <input type="url" class="appt-f-bg" placeholder="https://..."
+                           style="width:100%;padding:.4em .6em;border:1px solid var(--color-border);border-radius:4px;background:var(--color-main-background);color:var(--color-main-text)">
+                </label>
+                <label style="display:flex;flex-direction:column;gap:.25em;font-size:.9em;grid-column:1/-1">
+                    <?php p($l->t('Custom Email HTML Template')); ?>
+                    <span style="font-size:.85em;color:var(--color-text-maxcontrast)">
+                        <?php p($l->t('Available placeholders: {attendee_name}, {org_name}, {date_time}, {cancel_url}, {confirm_url}')); ?>
+                    </span>
+                    <textarea class="appt-f-email" rows="8" placeholder="<p>Dear {attendee_name},...</p>"
+                              style="width:100%;padding:.4em .6em;border:1px solid var(--color-border);border-radius:4px;font-family:monospace;font-size:.85em;background:var(--color-main-background);color:var(--color-main-text);resize:vertical"></textarea>
+                </label>
+            </div>
+            <div style="display:flex;gap:.6em">
+                <button class="appt-save-btn button primary" style="min-width:80px"><?php p($l->t('Save')); ?></button>
+                <button class="appt-delete-btn button" style="color:var(--color-error)"><?php p($l->t('Delete')); ?></button>
+                <span class="appt-brand-status" style="align-self:center;font-size:.85em;color:var(--color-success)"></span>
+            </div>
+        </div>
+    </template>
+</div>
+
+<style>
+#appt-branding-admin .button{cursor:pointer;padding:.4em 1em;border-radius:4px;border:1px solid var(--color-border)}
+#appt-branding-admin .button.primary{background:var(--color-primary);color:var(--color-primary-text);border-color:var(--color-primary)}
+</style>
+
+<script>
+(function () {
+    const listEl = document.getElementById('appt-brand-list')
+    const tpl = document.getElementById('appt-brand-tpl')
+    const addBtn = document.getElementById('appt-add-brand-btn')
+    const apiBase = <?php echo json_encode($apiBase); ?>
+    const saveUrl = <?php echo json_encode($saveUrl); ?>
+    const deleteUrl = <?php echo json_encode($deleteUrl); ?>
+
+    function renderCard(brand) {
+        const node = tpl.content.cloneNode(true)
+        const card = node.querySelector('.appt-brand-card')
+        card.querySelector('.appt-brand-id').value = brand.id || ''
+        card.querySelector('.appt-f-name').value = brand.name || ''
+        card.querySelector('.appt-f-color').value = brand.primaryColor || '#0082c9'
+        card.querySelector('.appt-f-logo').value = brand.logoUrl || ''
+        card.querySelector('.appt-f-favicon').value = brand.faviconUrl || ''
+        card.querySelector('.appt-f-bg').value = brand.bgImage || ''
+        card.querySelector('.appt-f-email').value = brand.emailTemplate || ''
+
+        card.querySelector('.appt-save-btn').addEventListener('click', () => saveBrand(card))
+        card.querySelector('.appt-delete-btn').addEventListener('click', () => deleteBrand(card))
+        listEl.appendChild(node)
+    }
+
+    function getToken() {
+        return document.cookie.split('; ').find(r => r.startsWith('nc_token='))?.split('=')[1]
+            || document.querySelector('head[data-requesttoken]')?.dataset?.requesttoken
+            || document.getElementById('initial-state-core-config') && JSON.parse(atob(document.getElementById('initial-state-core-config').innerText)).requesttoken
+            || ''
+    }
+
+    async function saveBrand(card) {
+        const statusEl = card.querySelector('.appt-brand-status')
+        const body = new FormData()
+        body.set('id', card.querySelector('.appt-brand-id').value)
+        body.set('name', card.querySelector('.appt-f-name').value)
+        body.set('primaryColor', card.querySelector('.appt-f-color').value)
+        body.set('logoUrl', card.querySelector('.appt-f-logo').value)
+        body.set('faviconUrl', card.querySelector('.appt-f-favicon').value)
+        body.set('bgImage', card.querySelector('.appt-f-bg').value)
+        body.set('emailTemplate', card.querySelector('.appt-f-email').value)
+
+        const res = await fetch(saveUrl, {
+            method: 'POST',
+            headers: {'requesttoken': OC.requestToken},
+            body
+        })
+        const data = await res.json()
+        if (res.ok) {
+            card.querySelector('.appt-brand-id').value = data.id
+            statusEl.textContent = '✓ Saved'
+            setTimeout(() => statusEl.textContent = '', 2500)
+        } else {
+            statusEl.style.color = 'var(--color-error)'
+            statusEl.textContent = data.error || 'Error'
+        }
+    }
+
+    async function deleteBrand(card) {
+        const id = card.querySelector('.appt-brand-id').value
+        if (!id || !confirm('Delete this brand?')) return
+        const body = new FormData()
+        body.set('id', id)
+        const res = await fetch(deleteUrl, {
+            method: 'POST',
+            headers: {'requesttoken': OC.requestToken},
+            body
+        })
+        if (res.ok) {
+            card.remove()
+        }
+    }
+
+    async function loadBrands() {
+        const res = await fetch(apiBase)
+        if (!res.ok) return
+        const brands = await res.json()
+        brands.forEach(renderCard)
+    }
+
+    addBtn.addEventListener('click', () => renderCard({}))
+
+    loadBrands()
+})()
+</script>

--- a/templates/admin_branding.php
+++ b/templates/admin_branding.php
@@ -50,6 +50,16 @@ $deleteUrl = \OC::$server->getURLGenerator()->linkToRoute('appointments.admin.de
                     <textarea class="appt-f-email" rows="8" placeholder="<p>Dear {attendee_name},...</p>"
                               style="width:100%;padding:.4em .6em;border:1px solid var(--color-border);border-radius:4px;font-family:monospace;font-size:.85em;background:var(--color-main-background);color:var(--color-main-text);resize:vertical"></textarea>
                 </label>
+                <label style="display:flex;flex-direction:column;gap:.25em;font-size:.9em;grid-column:1/-1">
+                    <?php p($l->t('Custom CSS')); ?>
+                    <textarea class="appt-f-css" rows="5" placeholder=".srgdev-ncfp-form { ... }"
+                              style="width:100%;padding:.4em .6em;border:1px solid var(--color-border);border-radius:4px;font-family:monospace;font-size:.85em;background:var(--color-main-background);color:var(--color-main-text);resize:vertical"></textarea>
+                </label>
+                <label style="display:flex;flex-direction:column;gap:.25em;font-size:.9em;grid-column:1/-1">
+                    <?php p($l->t('Custom JS')); ?>
+                    <textarea class="appt-f-js" rows="5" placeholder="// runs after page load"
+                              style="width:100%;padding:.4em .6em;border:1px solid var(--color-border);border-radius:4px;font-family:monospace;font-size:.85em;background:var(--color-main-background);color:var(--color-main-text);resize:vertical"></textarea>
+                </label>
             </div>
             <div style="display:flex;gap:.6em">
                 <button class="appt-save-btn button primary" style="min-width:80px"><?php p($l->t('Save')); ?></button>
@@ -84,6 +94,8 @@ $deleteUrl = \OC::$server->getURLGenerator()->linkToRoute('appointments.admin.de
         card.querySelector('.appt-f-favicon').value = brand.faviconUrl || ''
         card.querySelector('.appt-f-bg').value = brand.bgImage || ''
         card.querySelector('.appt-f-email').value = brand.emailTemplate || ''
+        card.querySelector('.appt-f-css').value = brand.customCss || ''
+        card.querySelector('.appt-f-js').value = brand.customJs || ''
 
         card.querySelector('.appt-save-btn').addEventListener('click', () => saveBrand(card))
         card.querySelector('.appt-delete-btn').addEventListener('click', () => deleteBrand(card))
@@ -107,6 +119,8 @@ $deleteUrl = \OC::$server->getURLGenerator()->linkToRoute('appointments.admin.de
         body.set('faviconUrl', card.querySelector('.appt-f-favicon').value)
         body.set('bgImage', card.querySelector('.appt-f-bg').value)
         body.set('emailTemplate', card.querySelector('.appt-f-email').value)
+        body.set('customCss', card.querySelector('.appt-f-css').value)
+        body.set('customJs', card.querySelector('.appt-f-js').value)
 
         const res = await fetch(saveUrl, {
             method: 'POST',

--- a/templates/public/form.php
+++ b/templates/public/form.php
@@ -2,6 +2,14 @@
 script('appointments', 'form');
 style('appointments', 'form');
 ?>
+<?php if (!empty($_['appt_brand']['faviconUrl'])): ?>
+<link rel="icon" href="<?php echo htmlspecialchars($_['appt_brand']['faviconUrl'], ENT_QUOTES); ?>">
+<?php endif; ?>
+<?php if (!empty($_['appt_brand']['logoUrl'])): ?>
+<div class="srgdev-appt-brand-logo" style="text-align:center;padding:1em 0 .5em">
+    <img src="<?php echo htmlspecialchars($_['appt_brand']['logoUrl'], ENT_QUOTES); ?>" alt="" style="max-height:60px;max-width:240px;object-fit:contain">
+</div>
+<?php endif; ?>
 
 <div class="srgdev-ncfp-wrap">
     <?php

--- a/templates/public/form.php
+++ b/templates/public/form.php
@@ -10,6 +10,12 @@ style('appointments', 'form');
     <img src="<?php echo htmlspecialchars($_['appt_brand']['logoUrl'], ENT_QUOTES); ?>" alt="" style="max-height:60px;max-width:240px;object-fit:contain">
 </div>
 <?php endif; ?>
+<?php if (!empty($_['appt_brand']['customCss'])): ?>
+<style><?php echo $_['appt_brand']['customCss']; ?></style>
+<?php endif; ?>
+<?php if (!empty($_['appt_brand']['customJs'])): ?>
+<script><?php echo $_['appt_brand']['customJs']; ?></script>
+<?php endif; ?>
 
 <div class="srgdev-ncfp-wrap">
     <?php

--- a/tests/Unit/BrandingTest.php
+++ b/tests/Unit/BrandingTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace OCA\Appointments\Tests\Unit;
+
+use OCA\Appointments\Backend\BackendUtils;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class BrandingTest extends TestCase
+{
+    /** @var IConfig&MockObject */
+    private IConfig $config;
+    private BackendUtils $utils;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(IConfig::class);
+        $this->utils = new BackendUtils(
+            $this->config,
+            $this->createMock(IDBConnection::class),
+            $this->createMock(IURLGenerator::class),
+            $this->createMock(IL10N::class),
+            $this->createMock(LoggerInterface::class),
+        );
+    }
+
+    public function testGetBrandsReturnsEmptyArrayWhenNotSet(): void
+    {
+        $this->config->method('getAppValue')->willReturn('');
+        $this->assertSame([], $this->utils->getBrands());
+    }
+
+    public function testGetBrandsReturnsEmptyArrayOnInvalidJson(): void
+    {
+        $this->config->method('getAppValue')->willReturn('not json');
+        $this->assertSame([], $this->utils->getBrands());
+    }
+
+    public function testGetBrandsReturnsParsedArray(): void
+    {
+        $brands = [
+            ['id' => 'brand_1', 'name' => 'Acme', 'logoUrl' => 'https://example.com/logo.png'],
+        ];
+        $this->config->method('getAppValue')->willReturn(json_encode($brands));
+        $this->assertSame($brands, $this->utils->getBrands());
+    }
+
+    public function testGetBrandReturnsNullWhenNotFound(): void
+    {
+        $this->config->method('getAppValue')->willReturn('[]');
+        $this->assertNull($this->utils->getBrand('nonexistent'));
+    }
+
+    public function testGetBrandReturnsMatchingBrand(): void
+    {
+        $brands = [
+            ['id' => 'brand_aaa', 'name' => 'Alpha'],
+            ['id' => 'brand_123', 'name' => 'Beta', 'logoUrl' => 'https://beta.example.com/logo.png'],
+        ];
+        $this->config->method('getAppValue')->willReturn(json_encode($brands));
+        $result = $this->utils->getBrand('brand_123');
+        $this->assertNotNull($result);
+        $this->assertSame('Beta', $result['name']);
+        $this->assertSame('https://beta.example.com/logo.png', $result['logoUrl']);
+    }
+
+    public function testSaveBrandsSerializesCorrectly(): void
+    {
+        $brands = [
+            ['id' => 'brand_x', 'name' => 'X Corp', 'primaryColor' => '#ff0000'],
+        ];
+        $this->config->expects($this->once())
+            ->method('setAppValue')
+            ->with(
+                'appointments',
+                BackendUtils::BRANDING_APP_CONFIG_KEY,
+                json_encode($brands)
+            );
+        $this->utils->saveBrands($brands);
+    }
+
+    public function testGetBrandReturnsFirstMatchOnly(): void
+    {
+        $brands = [
+            ['id' => 'brand_dup', 'name' => 'First'],
+            ['id' => 'brand_dup', 'name' => 'Second'],
+        ];
+        $this->config->method('getAppValue')->willReturn(json_encode($brands));
+        $result = $this->utils->getBrand('brand_dup');
+        $this->assertSame('First', $result['name']);
+    }
+
+    public function testSaveBrandsReindexesArray(): void
+    {
+        $brands = [2 => ['id' => 'brand_y', 'name' => 'Y']];
+        $this->config->expects($this->once())
+            ->method('setAppValue')
+            ->with(
+                'appointments',
+                BackendUtils::BRANDING_APP_CONFIG_KEY,
+                json_encode(array_values($brands))
+            );
+        $this->utils->saveBrands($brands);
+    }
+}


### PR DESCRIPTION
Closes #684

## What this adds

An admin-managed brand system for running Appointments across multiple brands/organizations from a single Nextcloud instance.

Admin defines brands under Admin settings → Appointments → Brands. Each brand has:

- Name
- Logo URL
- Favicon URL
- Background image URL
- Primary color (hex)
- Custom CSS
- Custom JS
- Custom HTML email template (\`{attendee_name}\`, \`{org_name}\`, \`{date_time}\`, \`{cancel_url}\` placeholders)

Each booking page gets a brand selector in its settings UI. The public form picks up the brand visuals; outgoing emails use the brand template if one is set.

## Files changed

| File | What |
|---|---|
| \`lib/Backend/BackendUtils.php\` | Brand constants, \`getBrands/getBrand/saveBrands\`, extended \`getInlineStyle(?array \$brand)\` |
| \`lib/Controller/AdminController.php\` | Admin CRUD: \`getBrands\`, \`saveBrand\`, \`deleteBrand\` |
| \`lib/Settings/BrandingAdminSettings.php\` | Nextcloud admin panel registration |
| \`lib/AppInfo/Application.php\` | \`registerAdmin(BrandingAdminSettings::class)\` |
| \`appinfo/routes.php\` | Three \`/admin/brands\` routes |
| \`templates/admin_branding.php\` | Self-contained HTML+JS admin UI, no build step |
| \`lib/Controller/PageController.php\` | Load brand per page, pass to \`getInlineStyle\` and template |
| \`lib/Backend/DavListener.php\` | Use brand email template when set |
| \`templates/public/form.php\` | Favicon, logo, custom CSS/JS injection |
| \`src/components/settings-v2/SectionPage.vue\` | Brand selector (hidden when no brands defined) |
| \`tests/Unit/BrandingTest.php\` | 7 unit tests for brand CRUD methods |

## Storage

Brands stored in \`appconfig\` as a JSON array under key \`branding_brands\`. No schema migration needed.

## Known gap

\`{confirm_url}\` in email templates maps to the same base URL as \`{cancel_url}\` for now. Separate confirm/cancel deep links need another pass into \`makeBtnInfo\`. Happy to add that before merge if you want it.

## Testing

Unit tests in \`tests/Unit/BrandingTest.php\` cover \`getBrands\`, \`getBrand\`, and \`saveBrands\` with mocked \`IConfig\`. Manual testing done on a local Nextcloud instance.